### PR TITLE
Clean up extra quote in quagga "ospf distance global" help command

### DIFF
--- a/templates/protocols/ospf/distance/global/node.def
+++ b/templates/protocols/ospf/distance/global/node.def
@@ -1,6 +1,6 @@
 type: u32
 help: OSPF administrative distance
-val_help: u32:1-255; Administrative distance"
+val_help: u32:1-255; Administrative distance
 
 syntax:expression: $VAR(@) >= 1 && $VAR(@) <= 255; "Must be between 1-255"
 


### PR DESCRIPTION
I noticed a minor typo today under [edit protocols ospf] when typing "set distance global" and hitting ? for help - it shows the help text literally as:
   <1-255>    Administrative distance"
...with the dangling quote on the end.
Traced it back here. I don't have a vyos build environment yet to confirm it, but it's a simple enough change anyway.
HTH!
