### PR TITLE
Expose as-override option in bgpd in vyos

### DIFF
--- a/scripts/bgp/vyatta-bgp.pl
+++ b/scripts/bgp/vyatta-bgp.pl
@@ -315,6 +315,10 @@ my %qcom = (
       set => 'router bgp #3 ; neighbor #5 allowas-in #8',
       del => 'router bgp #3 ; no neighbor #5 allowas-in ; neighbor #5 allowas-in',
   },
+  'protocols bgp var neighbor var as-override' => {
+      set => 'router bgp #3 ; neighbor #5 as-override',
+      del => 'router bgp #3 ; no neighbor #5 as-override',
+  },
   'protocols bgp var neighbor var attribute-unchanged' => {
       set => 'router bgp #3 ; no neighbor #5 attribute-unchanged ; neighbor #5 attribute-unchanged ?as-path ?med ?next-hop',
       del => 'router bgp #3 ; no neighbor #5 attribute-unchanged ?as-path ?med ?next-hop',

--- a/templates/protocols/bgp/node.tag/neighbor/node.tag/as-override/node.def
+++ b/templates/protocols/bgp/node.tag/neighbor/node.tag/as-override/node.def
@@ -1,0 +1,1 @@
+help: AS for routes sent to this neighbor to be the local AS


### PR DESCRIPTION
Cherry pick of a103c31b75abbfd6570783a066d9317b50abc123 that has landed in `helium`

Ref: https://phabricator.vyos.net/T275#7932