### PR TITLE
Added IPv4 in description to distinct from IPv6 BGP configuration.

### DIFF
--- a/templates/protocols/bgp/node.tag/neighbor/node.tag/allowas-in/node.def
+++ b/templates/protocols/bgp/node.tag/neighbor/node.tag/allowas-in/node.def
@@ -1,1 +1,1 @@
-help: Accept a route that contains the local-AS in the as-path
+help: Accept a IPv4-route that contains the local-AS in the as-path

--- a/templates/protocols/bgp/node.tag/neighbor/node.tag/allowas-in/number/node.def
+++ b/templates/protocols/bgp/node.tag/neighbor/node.tag/allowas-in/number/node.def
@@ -1,4 +1,4 @@
 type: u32
-help: Number of occurrences of AS number
+help: Number of occurrences of AS number (IPv4)
 val_help: u32:1-10; Number of times AS is allowed in path
 syntax:expression: $VAR(@) >= 1 && $VAR(@) <= 10; "allowas-in number must be between 1 and 10"

--- a/templates/protocols/bgp/node.tag/neighbor/node.tag/attribute-unchanged/as-path/node.def
+++ b/templates/protocols/bgp/node.tag/neighbor/node.tag/attribute-unchanged/as-path/node.def
@@ -1,1 +1,1 @@
-help: Send AS path unchanged
+help: Send AS path unchanged (IPv4)

--- a/templates/protocols/bgp/node.tag/neighbor/node.tag/attribute-unchanged/med/node.def
+++ b/templates/protocols/bgp/node.tag/neighbor/node.tag/attribute-unchanged/med/node.def
@@ -1,1 +1,1 @@
-help: Send multi-exit discriminator unchanged
+help: Send multi-exit discriminator unchanged (IPv4)

--- a/templates/protocols/bgp/node.tag/neighbor/node.tag/attribute-unchanged/next-hop/node.def
+++ b/templates/protocols/bgp/node.tag/neighbor/node.tag/attribute-unchanged/next-hop/node.def
@@ -1,1 +1,1 @@
-help: Send nexthop unchanged
+help: Send nexthop unchanged (IPv4)

--- a/templates/protocols/bgp/node.tag/neighbor/node.tag/attribute-unchanged/node.def
+++ b/templates/protocols/bgp/node.tag/neighbor/node.tag/attribute-unchanged/node.def
@@ -1,1 +1,1 @@
-help: BGP attributes are sent unchanged
+help: BGP attributes are sent unchanged (IPv4)

--- a/templates/protocols/bgp/node.tag/neighbor/node.tag/capability/node.def
+++ b/templates/protocols/bgp/node.tag/neighbor/node.tag/capability/node.def
@@ -1,1 +1,1 @@
-help: Advertise capabilities to this neighbor
+help: Advertise capabilities to this neighbor (IPv4)

--- a/templates/protocols/bgp/node.tag/neighbor/node.tag/default-originate/node.def
+++ b/templates/protocols/bgp/node.tag/neighbor/node.tag/default-originate/node.def
@@ -1,1 +1,1 @@
-help: Send default route to this neighbor
+help: Send default IPv4-route to this neighbor

--- a/templates/protocols/bgp/node.tag/neighbor/node.tag/default-originate/route-map/node.def
+++ b/templates/protocols/bgp/node.tag/neighbor/node.tag/default-originate/route-map/node.def
@@ -1,5 +1,5 @@
 type: txt
-help: Route-map to specify criteria of the default
+help: IPv4-Route-map to specify criteria of the default
 allowed: local -a params
         params=$(/opt/vyatta/sbin/vyatta-policy.pl --list-policy route-map)
         echo -n ${params[@]##*/}

--- a/templates/protocols/bgp/node.tag/neighbor/node.tag/disable-send-community/extended/node.def
+++ b/templates/protocols/bgp/node.tag/neighbor/node.tag/disable-send-community/extended/node.def
@@ -1,1 +1,1 @@
-help: Disable sending extended community attributes to this neighbor
+help: Disable sending extended community attributes to this neighbor (IPv4)

--- a/templates/protocols/bgp/node.tag/neighbor/node.tag/disable-send-community/node.def
+++ b/templates/protocols/bgp/node.tag/neighbor/node.tag/disable-send-community/node.def
@@ -1,2 +1,2 @@
-help: Disable sending community attributes to this neighbor
+help: Disable sending community attributes to this neighbor (IPv4)
 commit:expression: ($VAR(./extended/) != "") || ($VAR(./standard/) != ""); "you must specify the type of community"

--- a/templates/protocols/bgp/node.tag/neighbor/node.tag/disable-send-community/standard/node.def
+++ b/templates/protocols/bgp/node.tag/neighbor/node.tag/disable-send-community/standard/node.def
@@ -1,1 +1,1 @@
-help: Disable sending standard community attributes to this neighbor
+help: Disable sending standard community attributes to this neighbor (IPv4)

--- a/templates/protocols/bgp/node.tag/neighbor/node.tag/distribute-list/export/node.def
+++ b/templates/protocols/bgp/node.tag/neighbor/node.tag/distribute-list/export/node.def
@@ -1,5 +1,5 @@
 type: u32
-help: Access-list to filter outgoing route updates to this neighbor
+help: Access-list to filter outgoing IPv4-route updates to this neighbor
 val_help: u32:1-65535; Access list number
 
 syntax:expression: $VAR(@) >= 1 && $VAR(@) <= 65535; "Access list must be between 1 and 65535"

--- a/templates/protocols/bgp/node.tag/neighbor/node.tag/distribute-list/import/node.def
+++ b/templates/protocols/bgp/node.tag/neighbor/node.tag/distribute-list/import/node.def
@@ -1,5 +1,5 @@
 type: u32
-help: Access-list to filter incoming route updates from this neighbor
+help: Access-list to filter incoming IPv4-route updates from this neighbor
 val_help: u32:1-65535; Access-list number
 syntax:expression: $VAR(@) >= 1 && $VAR(@) <= 65535; "Access list must be between 1 and 65535"
 

--- a/templates/protocols/bgp/node.tag/neighbor/node.tag/distribute-list/node.def
+++ b/templates/protocols/bgp/node.tag/neighbor/node.tag/distribute-list/node.def
@@ -1,1 +1,1 @@
-help: Access-list to filter route updates to/from this neighbor
+help: Access-list to filter IPv4-route updates to/from this neighbor

--- a/templates/protocols/bgp/node.tag/neighbor/node.tag/filter-list/export/node.def
+++ b/templates/protocols/bgp/node.tag/neighbor/node.tag/filter-list/export/node.def
@@ -1,5 +1,5 @@
 type: txt
-help: As-path-list to filter outgoing route updates to this neighbor
+help: As-path-list to filter outgoing IPv4-route updates to this neighbor
 allowed: local -a params
         params=$( /opt/vyatta/sbin/vyatta-policy.pl --list-policy as-path-list )
         echo -n ${params[@]##*/}

--- a/templates/protocols/bgp/node.tag/neighbor/node.tag/filter-list/import/node.def
+++ b/templates/protocols/bgp/node.tag/neighbor/node.tag/filter-list/import/node.def
@@ -1,5 +1,5 @@
 type: txt
-help: As-path-list to filter incoming route updates from this neighbor
+help: As-path-list to filter incoming IPv4-route updates from this neighbor
 allowed: local -a params
         params=$( /opt/vyatta/sbin/vyatta-policy.pl --list-policy as-path-list )
         echo -n ${params[@]##*/}

--- a/templates/protocols/bgp/node.tag/neighbor/node.tag/filter-list/node.def
+++ b/templates/protocols/bgp/node.tag/neighbor/node.tag/filter-list/node.def
@@ -1,1 +1,1 @@
-help: As-path-list to filter route updates to/from this neighbor
+help: As-path-list to filter IPv4-route updates to/from this neighbor

--- a/templates/protocols/bgp/node.tag/neighbor/node.tag/maximum-prefix/node.def
+++ b/templates/protocols/bgp/node.tag/neighbor/node.tag/maximum-prefix/node.def
@@ -1,4 +1,4 @@
 type: u32
-help: Maximum number of prefixes to accept from this neighbor
+help: Maximum number of IPv4-prefixes to accept from this neighbor
 val_help: u32:1-4294967295; Prefix limit
 syntax:expression: $VAR(@) >= 1 && $VAR(@) <= 4294967295; "maximum-prefix must be between 1 and 4294967295"

--- a/templates/protocols/bgp/node.tag/neighbor/node.tag/nexthop-self/node.def
+++ b/templates/protocols/bgp/node.tag/neighbor/node.tag/nexthop-self/node.def
@@ -1,1 +1,1 @@
-help: Nexthop for routes sent to this neighbor to be the local router
+help: Nexthop for IPv4-routes sent to this neighbor to be the local router

--- a/templates/protocols/bgp/node.tag/neighbor/node.tag/prefix-list/export/node.def
+++ b/templates/protocols/bgp/node.tag/neighbor/node.tag/prefix-list/export/node.def
@@ -1,5 +1,5 @@
 type: txt
-help: Prefix-list to filter outgoing route updates to this neighbor
+help: IPv4-Prefix-list to filter outgoing route updates to this neighbor
 allowed: local -a params
         params=$( /opt/vyatta/sbin/vyatta-policy.pl --list-policy prefix-list )
         echo -n ${params[@]##*/}

--- a/templates/protocols/bgp/node.tag/neighbor/node.tag/prefix-list/import/node.def
+++ b/templates/protocols/bgp/node.tag/neighbor/node.tag/prefix-list/import/node.def
@@ -1,5 +1,5 @@
 type: txt
-help: Prefix-list to filter incoming route updates from this neighbor
+help: IPv4-Prefix-list to filter incoming route updates from this neighbor
 allowed: local -a params
         params=$( /opt/vyatta/sbin/vyatta-policy.pl --list-policy prefix-list )
         echo -n ${params[@]##*/}

--- a/templates/protocols/bgp/node.tag/neighbor/node.tag/prefix-list/node.def
+++ b/templates/protocols/bgp/node.tag/neighbor/node.tag/prefix-list/node.def
@@ -1,1 +1,1 @@
-help: Prefix-list to filter route updates to/from this neighbor
+help: IPv4-Prefix-list to filter route updates to/from this neighbor

--- a/templates/protocols/bgp/node.tag/neighbor/node.tag/remove-private-as/node.def
+++ b/templates/protocols/bgp/node.tag/neighbor/node.tag/remove-private-as/node.def
@@ -1,2 +1,2 @@
-help: Remove private AS numbers from AS path in outbound route updates
+help: Remove private AS numbers from AS path in outbound IPv4-route updates
 commit:expression: $VAR(../remote-as/@) != $VAR(../../@); "you can't set remove-private-as for an iBGP peer"

--- a/templates/protocols/bgp/node.tag/neighbor/node.tag/route-map/export/node.def
+++ b/templates/protocols/bgp/node.tag/neighbor/node.tag/route-map/export/node.def
@@ -1,5 +1,5 @@
 type: txt
-help: Route-map to filter outgoing route updates to this neighbor
+help: IPv4-Route-map to filter outgoing route updates to this neighbor
 allowed: local -a params
         params=$( /opt/vyatta/sbin/vyatta-policy.pl --list-policy route-map )
         echo -n ${params[@]##*/}

--- a/templates/protocols/bgp/node.tag/neighbor/node.tag/route-map/import/node.def
+++ b/templates/protocols/bgp/node.tag/neighbor/node.tag/route-map/import/node.def
@@ -1,5 +1,5 @@
 type: txt
-help: Route-map to filter incoming route updates from this neighbor
+help: IPv4-Route-map to filter incoming route updates from this neighbor
 allowed: local -a params
         params=$( /opt/vyatta/sbin/vyatta-policy.pl --list-policy route-map )
         echo -n ${params[@]##*/}

--- a/templates/protocols/bgp/node.tag/neighbor/node.tag/route-map/node.def
+++ b/templates/protocols/bgp/node.tag/neighbor/node.tag/route-map/node.def
@@ -1,1 +1,1 @@
-help: Route-map to filter route updates to/from this neighbor
+help: Route-map to filter IPv4-route updates to/from this neighbor

--- a/templates/protocols/bgp/node.tag/neighbor/node.tag/route-reflector-client/node.def
+++ b/templates/protocols/bgp/node.tag/neighbor/node.tag/route-reflector-client/node.def
@@ -1,2 +1,2 @@
-help: Neighbor as a route reflector client
+help: Neighbor as a IPv4-route reflector client
 commit:expression: $VAR(../../@) == $VAR(../remote-as/@); "remote-as must equal local-as"

--- a/templates/protocols/bgp/node.tag/neighbor/node.tag/route-server-client/node.def
+++ b/templates/protocols/bgp/node.tag/neighbor/node.tag/route-server-client/node.def
@@ -1,1 +1,1 @@
-help: Neighbor is route server client
+help: Neighbor is IPv4-route server client

--- a/templates/protocols/bgp/node.tag/neighbor/node.tag/soft-reconfiguration/node.def
+++ b/templates/protocols/bgp/node.tag/neighbor/node.tag/soft-reconfiguration/node.def
@@ -1,2 +1,2 @@
-help: Soft reconfiguration for neighbor
+help: Soft reconfiguration for neighbor (IPv4)
 commit:expression: $VAR(./inbound/) != ""; "you must specify the type of soft-reconfiguration"

--- a/templates/protocols/bgp/node.tag/neighbor/node.tag/unsuppress-map/node.def
+++ b/templates/protocols/bgp/node.tag/neighbor/node.tag/unsuppress-map/node.def
@@ -1,5 +1,5 @@
 type: txt
-help: Route-map to selectively unsuppress suppressed routes
+help: Route-map to selectively unsuppress suppressed IPv4-routes
 allowed: local -a params
         params=$( /opt/vyatta/sbin/vyatta-policy.pl --list-policy route-map )
         echo -n ${params[@]##*/}


### PR DESCRIPTION
I had problems configuring IPv6-BGP correctly as the descriptions did not clarify what is used for ipv4 only.

This PR mentions IPv4 at each setting in it's description at least as a hint.