### PR TITLE
T1136 - Fix typo: "Don not" to "Do not"

### DIFF
--- a/templates/protocols/bgp/node.tag/peer-group/node.tag/passive/node.def
+++ b/templates/protocols/bgp/node.tag/peer-group/node.tag/passive/node.def
@@ -1,1 +1,1 @@
-help: Don not intiate a session with this peer-group
+help: Do not intiate a session with this peer-group


### PR DESCRIPTION
This commit fixes T1136.

https://phabricator.vyos.net/T1136