### PR TITLE
Added support for replace-as in local-as BGP neighbor

### DIFF
--- a/scripts/bgp/vyatta-bgp.pl
+++ b/scripts/bgp/vyatta-bgp.pl
@@ -534,6 +534,10 @@ my %qcom = (
       set => 'router bgp #3 ; no neighbor #5 local-as #7 ; neighbor #5 local-as #7 no-prepend',
       del => 'router bgp #3 ; no neighbor #5 local-as #7 no-prepend ; neighbor #5 local-as #7',
   },
+  'protocols bgp var neighbor var local-as var no-prepend replace-as' => {
+      set => 'router bgp #3 ; no neighbor #5 local-as #7 ; neighbor #5 local-as #7 no-prepend replace-as',
+      del => 'router bgp #3 ; neighbor #5 local-as #7 no-prepend',
+  },
   'protocols bgp var neighbor var override-capability' => {
       set => 'router bgp #3 ; neighbor #5 override-capability',
       del => 'router bgp #3 ; no neighbor #5 override-capability',

--- a/templates/protocols/bgp/node.tag/neighbor/node.tag/local-as/node.tag/no-prepend/replace-as/node.def
+++ b/templates/protocols/bgp/node.tag/neighbor/node.tag/local-as/node.tag/no-prepend/replace-as/node.def
@@ -1,0 +1,1 @@
+help: Only prepend local-as when transmitting local-route updates to this peer.


### PR DESCRIPTION
Adds support for [replace-as](http://docs.frrouting.org/en/latest/bgp.html#clicmd-[no]neighborPEERlocal-asAS-NUMBERno-prependreplace-as) to VyOS.