### PR TITLE
T1499: Allow for usage of systemd interface mappings

### DIFF
--- a/templates/protocols/static/route/node.tag/dhcp-interface/node.def
+++ b/templates/protocols/static/route/node.tag/dhcp-interface/node.def
@@ -2,7 +2,7 @@ type: txt
 help: DHCP interface that supplies the next-hop IP address for this static route
 allowed:
         local -a array ;
-        array=( /var/lib/dhcp/eth* /var/lib/dhcp/br* /var/lib/dhcp/bond* ) ;
+        array=( /var/lib/dhcp/en* /var/lib/dhcp/eth* /var/lib/dhcp/br* /var/lib/dhcp/bond* ) ;
         echo  -n ${array[@]##*/}
 create:
         sudo /opt/vyatta/sbin/vyatta-update-static-route.pl --interface=$VAR(@) --route=$VAR(../@) --table=main --option=create

--- a/templates/protocols/static/table/node.tag/route/node.tag/dhcp-interface/node.def
+++ b/templates/protocols/static/table/node.tag/route/node.tag/dhcp-interface/node.def
@@ -2,7 +2,7 @@ type: txt
 help: DHCP interface that supplies the next-hop IP address for this static route
 allowed:
         local -a array ;
-        array=( /var/lib/dhcp/eth* /var/lib/dhcp/br* /var/lib/dhcp/bond* ) ;
+        array=( /var/lib/dhcp/en* /var/lib/dhcp/eth* /var/lib/dhcp/br* /var/lib/dhcp/bond* ) ;
         echo  -n ${array[@]##*/}
 create:
         ifc="$VAR(@)"


### PR DESCRIPTION
This PR allows the use of systemd named interfaces for ethernet.
this might get used when migrating over to buster with systemd default mappings. 