### PR TITLE
T1529: Fix interface name detection

### DIFF
--- a/scripts/bgp/vyatta-bgp.pl
+++ b/scripts/bgp/vyatta-bgp.pl
@@ -1207,8 +1207,9 @@ sub list_peer_groups {
 sub check_neighbor_ip {
     my $neighbor = shift;
 
-    if ($neighbor =~ /^(\w+)$/) {
-	    exit 0;
+    my $found = grep { $_ eq $neighbor } Vyatta::Misc::getInterfaces();
+    if ($found != 0) {
+            exit 0;
     }
 
     die "Can't set neighbor address to local system IP.\n"


### PR DESCRIPTION
Detection of interface names was wrong. This is now fixed. 
Author of  Bug T1529 has already confirmed it.
 