### PR TITLE
[BGP] T1490: Deleted bgp scan-time parameter

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -21,7 +21,7 @@ share_perl5_DATA = lib/Vyatta/Quagga/Config.pm
 
 src_check_prefix_boundary = src/check_prefix_boundary.c
 
-curver_DATA = cfg-version/quagga@3
+curver_DATA = cfg-version/quagga@4
 
 cpiop = find  . ! -regex '\(.*~\|.*\.bak\|.*\.swp\|.*\#.*\#\)' -print0 | \
 	cpio -0pd

--- a/scripts/bgp/vyatta-bgp.pl
+++ b/scripts/bgp/vyatta-bgp.pl
@@ -764,10 +764,6 @@ my %qcom = (
       set => 'router bgp #3 ; bgp router-id #6',
       del => 'router bgp #3 ; no bgp router-id #6',
   },
-  'protocols bgp var parameters scan-time' => {
-      set => 'router bgp #3 ; bgp scan-time #6',
-      del => 'router bgp #3 ; no bgp scan-time #6',
-  },
   'protocols bgp var peer-group' => {
       set => undef,
       del => undef,

--- a/templates/protocols/bgp/node.tag/parameters/scan-time/node.def
+++ b/templates/protocols/bgp/node.tag/parameters/scan-time/node.def
@@ -1,4 +1,0 @@
-type: u32
-help: BGP route scanner interval
-val_help: u32:5-60; Scan interval in seconds
-syntax:expression: $VAR(@) >= 5 && $VAR(@) <= 60; "scan-time must be between 5 and 60 seconds"


### PR DESCRIPTION
Deleted obsoleted BGP scan-time parameter, as it never existed in FRRouting as unneeded - there is used more modern next-hop tracking instead.