### PR TITLE
BGP: T1817: Added nexthop-self force option

### DIFF
--- a/scripts/bgp/vyatta-bgp.pl
+++ b/scripts/bgp/vyatta-bgp.pl
@@ -306,6 +306,10 @@ my %qcom = (
       set => 'router bgp #3 ; address-family ipv6 ; neighbor #5 next-hop-self',
       del => 'router bgp #3 ; address-family ipv6 ; no neighbor #5 next-hop-self',
   },
+  'protocols bgp var neighbor var address-family ipv6-unicast nexthop-self force' => {
+      set => 'router bgp #3 ; address-family ipv6 ; neighbor #5 next-hop-self force',
+      del => 'router bgp #3 ; address-family ipv6 ; no neighbor #5 next-hop-self force',
+  },
   'protocols bgp var neighbor var address-family ipv6-unicast peer-group' => {
       set => 'router bgp #3 ; address-family ipv6 ; neighbor #5 peer-group #9',
       del => 'router bgp #3 ; address-family ipv6 ; no neighbor #5 peer-group #9 ; neighbor #5 activate',
@@ -450,6 +454,10 @@ my %qcom = (
   'protocols bgp var neighbor var address-family ipv4-unicast nexthop-self' => {
       set => 'router bgp #3 ; address-family ipv4 unicast ; neighbor #5 next-hop-self',
       del => 'router bgp #3 ; address-family ipv4 unicast ; no neighbor #5 next-hop-self',
+  },
+  'protocols bgp var neighbor var address-family ipv4-unicast nexthop-self force' => {
+      set => 'router bgp #3 ; address-family ipv4 unicast ; neighbor #5 next-hop-self force',
+      del => 'router bgp #3 ; address-family ipv4 unicast ; no neighbor #5 next-hop-self force',
   },
   'protocols bgp var neighbor var address-family ipv4-unicast prefix-list' => {
       set => undef,
@@ -873,6 +881,10 @@ my %qcom = (
       set => 'router bgp #3 ; address-family ipv6 ; neighbor #5 next-hop-self',
       del => 'router bgp #3 ; address-family ipv6 ; no neighbor #5 next-hop-self',
   },
+  'protocols bgp var peer-group var address-family ipv6-unicast nexthop-self force' => {
+      set => 'router bgp #3 ; address-family ipv6 ; neighbor #5 next-hop-self force',
+      del => 'router bgp #3 ; address-family ipv6 ; no neighbor #5 next-hop-self force',
+  },
   'protocols bgp var peer-group var address-family ipv6-unicast prefix-list' => {
       set => undef,
       del => undef,
@@ -1010,6 +1022,10 @@ my %qcom = (
   'protocols bgp var peer-group var address-family ipv4-unicast nexthop-self' => {
       set => 'router bgp #3 ; address-family ipv4 unicast ; neighbor #5 next-hop-self',
       del => 'router bgp #3 ; address-family ipv4 unicast ; no neighbor #5 next-hop-self',
+  },
+  'protocols bgp var peer-group var address-family ipv4-unicast nexthop-self force' => {
+      set => 'router bgp #3 ; address-family ipv4 unicast ; neighbor #5 next-hop-self force',
+      del => 'router bgp #3 ; address-family ipv4 unicast ; no neighbor #5 next-hop-self force',
   },
   'protocols bgp var peer-group var address-family ipv4-unicast prefix-list' => {
       set => undef,

--- a/templates/protocols/bgp/node.tag/neighbor/node.tag/address-family/ipv4-unicast/nexthop-self/force/node.def
+++ b/templates/protocols/bgp/node.tag/neighbor/node.tag/address-family/ipv4-unicast/nexthop-self/force/node.def
@@ -1,0 +1,1 @@
+help: Set the next hop to self for reflected routes

--- a/templates/protocols/bgp/node.tag/neighbor/node.tag/address-family/ipv6-unicast/nexthop-self/force/node.def
+++ b/templates/protocols/bgp/node.tag/neighbor/node.tag/address-family/ipv6-unicast/nexthop-self/force/node.def
@@ -1,0 +1,1 @@
+help: Set the next hop to self for reflected routes

--- a/templates/protocols/bgp/node.tag/peer-group/node.tag/address-family/ipv4-unicast/nexthop-self/force/node.def
+++ b/templates/protocols/bgp/node.tag/peer-group/node.tag/address-family/ipv4-unicast/nexthop-self/force/node.def
@@ -1,0 +1,1 @@
+help: Set the next hop to self for reflected routes

--- a/templates/protocols/bgp/node.tag/peer-group/node.tag/address-family/ipv6-unicast/nexthop-self/force/node.def
+++ b/templates/protocols/bgp/node.tag/peer-group/node.tag/address-family/ipv6-unicast/nexthop-self/force/node.def
@@ -1,0 +1,1 @@
+help: Set the next hop to self for reflected routes


### PR DESCRIPTION
A simple "nexthop-self" command does not affect route-reflector clients, we need to additionally use "force" for them.
This change adding "force" to both ipv4-unicast and ipv6-unicast families in neighbor and peer-group sections.