### PR TITLE
Fixed large-community-list frr configuration generation

### DIFF
--- a/templates/policy/large-community-list/node.def
+++ b/templates/policy/large-community-list/node.def
@@ -2,3 +2,5 @@ tag:
 priority: 470
 type: txt
 help: Border Gateway Protocol (BGP) large-community-list filter
+
+end: /opt/vyatta/sbin/vyatta-policy.pl --update-large-community-list $VAR(@)

--- a/templates/policy/large-community-list/node.tag/rule/node.def
+++ b/templates/policy/large-community-list/node.tag/rule/node.def
@@ -4,17 +4,3 @@ help: create a rule for this BGP large-community list
 val_help: u32:1-65535; large-community-list rule number
 
 syntax:expression: $VAR(@) >= 1 && $VAR(@) <= 65535; "rule number must be between 1 and 65535"
-
-commit:expression: $VAR(./regex/) != ""; "You must specify a regex"
-commit:expression: $VAR(./action/) != ""; "You must specify an action"
-
-end:
-    # If the rule exists in the running config
-    if cli-shell-api existsActive policy large-community-list $VAR(../@) rule $VAR(@); then
-        orig_action=$(cli-shell-api returnActiveValue policy large-community-list $VAR(../@) rule $VAR(@) action)
-        orig_regex=$(cli-shell-api returnActiveValue policy large-community-list $VAR(../@) rule $VAR(@) regex)
-        vtysh -c "configure terminal" -c "no bgp large-community-list expanded $VAR(../@) $orig_action $VAR(@) regex $orig_regex"
-    fi
-    if [[ ${COMMIT_ACTION} != 'DELETE' ]]; then
-        vtysh -c "configure terminal" -c "bgp large-community-list expanded $VAR(../@) $VAR(./action/@) $VAR(@) regex $VAR(./regex/@)"
-    fi

--- a/templates/policy/large-community-list/node.tag/rule/node.tag/regex/node.def
+++ b/templates/policy/large-community-list/node.tag/rule/node.tag/regex/node.def
@@ -1,3 +1,5 @@
 type: txt
 help: Regular expression to match against a community list
 val_help: Community list regular expression
+
+commit:expression: $VAR(../action/@) != ""; "You must specify an action"


### PR DESCRIPTION
Currently large-community-lists create a non funtional frr configuration, and are therefor unusable, this patch, migrates the
generation for large-community-lists to the same perl file as the normal communities and generates a working configuration.