### PR TITLE
ospfv3: T2021: Change type validator for area

### DIFF
--- a/templates/protocols/ospfv3/area/node.def
+++ b/templates/protocols/ospfv3/area/node.def
@@ -1,5 +1,5 @@
 tag:
-type: txt
+type: ipv4
 help: OSPFv3 Area
 syntax:expression: exec "/opt/vyatta/sbin/vyatta_quagga_utils.pl --check-ospfv3-area $VAR(@)"; "Invalid OSFPv3 area \"$VAR(@)\" "
 val_help: ipv4; OSPFv3 area in dotted decimal notation


### PR DESCRIPTION
Change validator type for ospv3 area
FRR supports the only x.x.x.x value for interface area
```
r1-roll(config-ospf6)# interface eth1 area 
  A.B.C.D  OSPF6 area ID in IPv4 address notation
```