### PR TITLE
T2790: Add ip protocol route-map for OSPFv3 and ripng

### DIFF
--- a/templates/protocols/ospfv3/route-map/node.def
+++ b/templates/protocols/ospfv3/route-map/node.def
@@ -1,0 +1,8 @@
+type: txt
+help: Filter routes installed in local route map
+allowed: local -a params
+        params=$( /opt/vyatta/sbin/vyatta-policy.pl --list-policy route-map )
+        echo -n ${params[@]##*/}
+commit:expression: exec "/opt/vyatta/sbin/vyatta_quagga_utils.pl --exists \"policy route-map $VAR(@)\" ";"route-map $VAR(@) doesn't exist"
+create:expression: "vtysh -c \"configure terminal\" -c \"ipv6 protocol ospf6 route-map $VAR(@)\" "
+delete:expression: "vtysh -c \"configure terminal\" -c \"no ipv6 protocol ospf6\" "

--- a/templates/protocols/ripng/route-map/node.def
+++ b/templates/protocols/ripng/route-map/node.def
@@ -1,0 +1,8 @@
+type: txt
+help: Filter routes installed in local route map
+allowed: local -a params
+        params=$( /opt/vyatta/sbin/vyatta-policy.pl --list-policy route-map )
+        echo -n ${params[@]##*/}
+commit:expression: exec "/opt/vyatta/sbin/vyatta_quagga_utils.pl --exists \"policy route-map $VAR(@)\" ";"route-map $VAR(@) doesn't exist"
+create:expression: "vtysh -c \"configure terminal\" -c \"ipv6 protocol ripng route-map $VAR(@)\" "
+delete:expression: "vtysh -c \"configure terminal\" -c \"no ipv6 protocol ripng\" "


### PR DESCRIPTION
Presently you can set a route-map on OSPF and BGP to filter RIB routes from making it into the FIB. Add this ability for OSPFv3 and ripng as well.