### PR TITLE
vyatta-cfg-quagga: T2828: Remove deprecated bgp enforce-first-as

### DIFF
--- a/scripts/bgp/vyatta-bgp.pl
+++ b/scripts/bgp/vyatta-bgp.pl
@@ -744,10 +744,6 @@ my %qcom = (
       set => 'router bgp #3 ; distance #9 #7 ',
       del => 'router bgp #3 ; no distance #9 #7',
   },
-  'protocols bgp var parameters enforce-first-as' => {
-      set => 'router bgp #3 ; bgp enforce-first-as',
-      del => 'router bgp #3 ; no bgp enforce-first-as',
-  },
   'protocols bgp var parameters graceful-restart' => {
       set => undef,
       del => undef,

--- a/templates/protocols/bgp/node.tag/parameters/enforce-first-as/node.def
+++ b/templates/protocols/bgp/node.tag/parameters/enforce-first-as/node.def
@@ -1,1 +1,0 @@
-help: Require first AS in the path to match peer's AS


### PR DESCRIPTION
"enforce-first-as" was deleted from frr global BGP section

