### PR TITLE
op-mode: T3091: Add option tag for blackhole static routes

### DIFF
--- a/templates/protocols/static/route/node.tag/blackhole/node.def
+++ b/templates/protocols/static/route/node.tag/blackhole/node.def
@@ -9,8 +9,16 @@ end: if [ ${COMMIT_ACTION} = 'DELETE' ]; then
                     -c "no ip route $VAR(../@) Null0";
      else
        if [ -n "$VAR(./distance/@)" ]; then
-	 DIST="$VAR(./distance/@)";
+         DIST="$VAR(./distance/@)";
+       fi
+       if [ -n "$VAR(./tag/@)" ]; then
+         TAG="$VAR(./tag/@)";
        fi;
-       vtysh -c "configure terminal" \
-                    -c "ip route $VAR(../@) Null0 $DIST";
+       if [[ -z $TAG ]]; then
+           vtysh -c "configure terminal" \
+                 -c "ip route $VAR(../@) Null0 $DIST";
+       else
+           vtysh -c "configure terminal" \
+                 -c "ip route $VAR(../@) Null0 tag $TAG $DIST";
+       fi;
      fi;

--- a/templates/protocols/static/route/node.tag/blackhole/tag/node.def
+++ b/templates/protocols/static/route/node.tag/blackhole/tag/node.def
@@ -1,0 +1,4 @@
+type: u32
+help: Tag value for this route
+syntax:expression: $VAR(@) >= 1 && $VAR(@) <= 4294967295; "Must be between (1-4294967295)"
+val_help: u32:1-4294967295; Tag for this route


### PR DESCRIPTION
Ability to set a tag for blackhole routes
```
set protocols static route 203.0.113.6/32 blackhole tag 666
```
Show route
```
vyos@r5# run show ip route 203.0.113.6
Routing entry for 203.0.113.6/32
  Known via "static", distance 1, metric 0, tag 666, best
  Last update 00:00:36 ago
  * unreachable (blackhole), weight 1

```