### PR TITLE
bgp: T3184: Add description handler for neighbor

### DIFF
--- a/scripts/bgp/vyatta-bgp.pl
+++ b/scripts/bgp/vyatta-bgp.pl
@@ -206,6 +206,10 @@ my %qcom = (
       del => 'router bgp #3 ; no neighbor #5',
       noerr => 'del',
   },
+  'protocols bgp var neighbor var description' => {
+      set => 'router bgp #3 ; neighbor #5 description #7',
+      del => 'router bgp #3 ; no neighbor #5 description',
+  },
   'protocols bgp var neighbor var address-family' => {
       set => undef,
       del => undef,


### PR DESCRIPTION
Add a correct description (via a handler) in frr for the specific bgp neighbor

```
vyos@r5-roll# set protocols bgp 64456 neighbor 192.0.2.2 description FooBAR
[edit]
vyos@r5-roll# commit
[edit]
vyos@r5-roll# vtysh -c "show run" | grep neigh
 neighbor 192.0.2.2 remote-as 64500
 neighbor 192.0.2.2 description FooBAR
[edit]

```