### PR TITLE
ospf: T3194: Fix redistribute mertic values

### DIFF
--- a/templates/protocols/ospf/redistribute/bgp/metric/node.def
+++ b/templates/protocols/ospf/redistribute/bgp/metric/node.def
@@ -1,4 +1,4 @@
 type: u32
 help: Metric for redistributed routes
-syntax:expression: $VAR(@) >= 1 && $VAR(@) <= 16; "metric must be between 1 and 16"
-val_help: u32:1-16; Metric for redistributed routes
+syntax:expression: $VAR(@) >= 0 && $VAR(@) <= 16777214; "metric must be between 0 and 16777214"
+val_help: u32:0-16777214; Metric for redistributed routes

--- a/templates/protocols/ospf/redistribute/connected/metric/node.def
+++ b/templates/protocols/ospf/redistribute/connected/metric/node.def
@@ -1,4 +1,4 @@
 type: u32
 help: Metric for redistributed routes
-syntax:expression: $VAR(@) >= 1 && $VAR(@) <= 16; "metric must be between 1 and 16"
-val_help: u32:1-16; Metric for redistributed routes
+syntax:expression: $VAR(@) >= 0 && $VAR(@) <= 16777214; "metric must be between 0 and 16777214"
+val_help: u32:0-16777214; Metric for redistributed routes

--- a/templates/protocols/ospf/redistribute/kernel/metric/node.def
+++ b/templates/protocols/ospf/redistribute/kernel/metric/node.def
@@ -1,4 +1,4 @@
 type: u32
 help: Metric for redistributed routes
-syntax:expression: $VAR(@) >= 1 && $VAR(@) <= 16; "metric must be between 1 and 16"
-val_help: u32:1-16; Metric for redistributed routes
+syntax:expression: $VAR(@) >= 0 && $VAR(@) <= 16777214; "metric must be between 0 and 16777214"
+val_help: u32:0-16777214; Metric for redistributed routes

--- a/templates/protocols/ospf/redistribute/rip/metric/node.def
+++ b/templates/protocols/ospf/redistribute/rip/metric/node.def
@@ -1,4 +1,4 @@
 type: u32
 help: Metric for redistributed routes
-syntax:expression: $VAR(@) >= 1 && $VAR(@) <= 16; "metric must be between 1 and 16"
-val_help: u32:1-16; Metric for redistributed routes
+syntax:expression: $VAR(@) >= 0 && $VAR(@) <= 16777214; "metric must be between 0 and 16777214"
+val_help: u32:0-16777214; Metric for redistributed routes

--- a/templates/protocols/ospf/redistribute/static/metric/node.def
+++ b/templates/protocols/ospf/redistribute/static/metric/node.def
@@ -1,4 +1,4 @@
 type: u32
 help: Metric for redistributed routes
-syntax:expression: $VAR(@) >= 1 && $VAR(@) <= 16; "metric must be between 1 and 16"
-val_help: u32:1-16; Metric for redistributed routes
+syntax:expression: $VAR(@) >= 0 && $VAR(@) <= 16777214; "metric must be between 0 and 16777214"
+val_help: u32:0-16777214; Metric for redistributed routes


### PR DESCRIPTION
Change metric values for "set protocols ospf redistribute xxx metrix x"
It was 1-16 (it seems in old quagga), but actual FRR values 0-16777214

```
set protocols ospf redistribute bgp metric '0'
set protocols ospf redistribute connected metric '1600'
```
Vtysh
```
!
router ospf
 redistribute connected metric 1600
 redistribute bgp metric 0
!

```
Can be cherry-picked to 1.3
