### PR TITLE
rpki: T3230: Fix delete section for protocol rpki

### DIFF
--- a/scripts/vyos-update-rpki-cache.py
+++ b/scripts/vyos-update-rpki-cache.py
@@ -39,6 +39,13 @@ def create_cache(c, cache):
 
 def delete_cache(c, cache):
     ssh = False
+    port = c.return_effective_value(base_path + "cache {0} port".format(cache))
+    addr = c.return_effective_value(base_path + "cache {0} address".format(cache))
+    pref = c.return_effective_value(base_path + "cache {0} preference".format(cache))
+
+    if not pref:
+        pref = 1
+
     if c.exists_effective(base_path + "cache {0} ssh".format(cache)):
         ssh = True
         user = c.return_effective_value(base_path + "cache {0} ssh username".format(cache))
@@ -46,17 +53,11 @@ def delete_cache(c, cache):
         privkey = c.return_effective_value(base_path + "cache {0} ssh private-key-file".format(cache))
         known_hosts = c.return_effective_value(base_path + "cache {0} ssh known-hosts-file".format(cache))
 
-        port = c.return_effective_value(base_path + "cache {0} port".format(cache))
-        addr = c.return_effective_value(base_path + "cache {0} address".format(cache))
-        pref = c.return_effective_value(base_path + "cache {0} preference".format(cache))
-
-        if not pref:
-            pref = 1
-
         if ssh:
             subprocess.call(""" vtysh -c 'conf t' -c 'rpki' -c 'no rpki cache {0} {1} {2} {3} {4} {5} preference {6}' """.format(addr, port, user, privkey, pubkey, known_hosts, pref), shell=True)
-        else:
-            subprocess.call(""" vtysh -c 'conf t' -c 'rpki' -c 'no rpki cache {0} {1} preference {2}' """.format(addr, port, pref), shell=True)
+
+    else:
+        subprocess.call(""" vtysh -c 'conf t' -c 'rpki' -c 'no rpki cache {0} {1} preference {2}' """.format(addr, port, pref), shell=True)
 
 
 config = vyos.config.Config()


### PR DESCRIPTION
In the file vyos-update-rpki-cache.py "rpki" can be deleted only if "ssh" exist in rpki configuration

```
set protocols rpki cache routinator ssh xxx
```
It can't delete configuration like:
```
set protocols rpki cache routinator address 192.0.2.2
set protocols rpki cache routinator port 3333
```

That commit fixes it.