### PR TITLE
ospfv3: T3246: Fix config parameter router-id

### DIFF
--- a/templates/protocols/ospfv3/node.def
+++ b/templates/protocols/ospfv3/node.def
@@ -3,10 +3,10 @@ help: IPv6 Open Shortest Path First protocol (OSPFv3) parameters
 begin: if [ "$COMMIT_ACTION" != DELETE ]; then
          if [ -n "$VAR(parameters/router-id/@)" ]; then
            vtysh -c "configure terminal" -c "router ospf6" \
-                 -c "router-id $VAR(parameters/router-id/@)"
+                 -c "ospf6 router-id $VAR(parameters/router-id/@)"
          else
            vtysh -c "configure terminal" -c "router ospf6" \
-                 -c "no router-id"
+                 -c "no ospf6 router-id"
          fi
          vtysh -d ospf6d -c 'sh run' > /opt/vyatta/etc/quagga/ospf6d.conf
        fi


### PR DESCRIPTION
That commit fix configuration for ospfv3 router-id, which was configured as "global zebra parameter"
So router-id was out of the section **ospf6**
For example
```
set protocols ospfv3 area 0.0.0.0 interface 'eth1'
set protocols ospfv3 area 0.0.0.0 range 2001:db8:1111::/64
set protocols ospfv3 parameters router-id '1.1.1.2'

```
FRR
```
!
ip route 0.0.0.0/0 192.168.122.1
!
router-id 1.1.1.2
!
router ospf6
 redistribute connected

```
Expected behavior router-id should be in the ospf6 section, ref http://docs.frrouting.org/en/latest/ospf6d.html
```
!
router ospf6
 ospf6 router-id 1.1.1.2
 area 0.0.0.0 range 2001:db8:1111::/64
 interface eth1 area 0.0.0.0
!

```


