### PR TITLE
bgp: T3085: Add parameter weight for ipv6 neighbor

### DIFF
--- a/scripts/bgp/vyatta-bgp.pl
+++ b/scripts/bgp/vyatta-bgp.pl
@@ -214,6 +214,10 @@ my %qcom = (
       set => 'router bgp #3 ; address-family ipv4 unicast ; neighbor #5 weight #9',
       del => 'router bgp #3 ; address-family ipv4 unicast ; no neighbor #5 weight #9',
   },
+  'protocols bgp var neighbor var address-family ipv6-unicast weight' => {
+      set => 'router bgp #3 ; address-family ipv6 unicast ; neighbor #5 weight #9',
+      del => 'router bgp #3 ; address-family ipv6 unicast ; no neighbor #5 weight #9',
+  },
   'protocols bgp var neighbor var address-family ipv6-unicast' => {
       set => 'router bgp #3 ; address-family ipv6 ; neighbor #5 activate',
       del => 'router bgp #3 ; address-family ipv6 ; no neighbor #5 activate',

--- a/templates/protocols/bgp/node.tag/neighbor/node.tag/address-family/ipv6-unicast/weight/node.def
+++ b/templates/protocols/bgp/node.tag/neighbor/node.tag/address-family/ipv6-unicast/weight/node.def
@@ -1,0 +1,4 @@
+type: u32
+help: Default weight for routes from this neighbor
+val_help: u32: 1-65535; Weight for routes from this neighbor
+syntax:expression: $VAR(@) >= 1 && $VAR(@) <= 65535; "weight must be between 1 and 65535"


### PR DESCRIPTION

Add option weight for ipv6 neighbor
Config:
```
set protocols bgp 65001 neighbor 2001:db8::2 address-family ipv6-unicast weight '222'
```
Check:
```
vyos@r5-roll# run show ipv6 bgp
BGP table version is 6, local router ID is 192.168.168.5, vrf id 0

   Network          Next Hop            Metric LocPrf Weight Path
*> 2001:db8:aa::/64 fe80::5054:ff:fe43:b82a
                                             0           222 65002 i

```
