### PR TITLE
policy: T3301: Fix valueHelp for as-path-list

### DIFF
--- a/templates/policy/as-path-list/node.tag/rule/node.tag/regex/node.def
+++ b/templates/policy/as-path-list/node.tag/rule/node.tag/regex/node.def
@@ -1,6 +1,6 @@
 type: txt
 help: Regular expression to match against an AS path
-val_help: <aa:nn>; AS path regular expression (ex: "50:1 6553:1201")
+val_help: <asn>; AS path regular expression (ex: "64501 64502")
 # TODO: check regex syntax; \
 #       "invalid chars in regex syntax"
 


### PR DESCRIPTION
Fix valueHelp and format for policy as-path-list

```
vyos@r2-roll# set policy as-path-list FOO rule 10 regex 
Possible completions:
   <asn>        AS path regular expression (ex: "64501 64502")
```