### PR TITLE
routing: T3211: Add redistribute protocol IS-IS to bgp ospf

### DIFF
--- a/scripts/bgp/vyatta-bgp.pl
+++ b/scripts/bgp/vyatta-bgp.pl
@@ -165,6 +165,21 @@ my %qcom = (
       del => 'router bgp #3 ; address-family ipv4 unicast ; no redistribute connected route-map #9',
       noerr => 'set',
   },
+  'protocols bgp var address-family ipv4-unicast redistribute isis' => {
+      set => 'router bgp #3 ; address-family ipv4 unicast ; redistribute isis ?route-map ?metric',
+      del => 'router bgp #3 ; address-family ipv4 unicast ; no redistribute isis',
+      noerr => 'set',
+  },
+  'protocols bgp var address-family ipv4-unicast redistribute isis metric' => {
+      set => 'router bgp #3 ; address-family ipv4 unicast ; redistribute isis metric #9',
+      del => 'router bgp #3 ; address-family ipv4 unicast ; no redistribute isis metric #9',
+      noerr => 'set',
+  },
+  'protocols bgp var address-family ipv4-unicast redistribute isis route-map' => {
+      set => 'router bgp #3 ; address-family ipv4 unicast ; redistribute isis route-map #9',
+      del => 'router bgp #3 ; address-family ipv4 unicast ; no redistribute isis route-map #9',
+      noerr => 'set',
+  },
   'protocols bgp var address-family ipv4-unicast redistribute kernel' => {
       set => 'router bgp #3 ; address-family ipv4 unicast ; no redistribute kernel ; redistribute kernel ?route-map ?metric',
       del => 'router bgp #3 ; address-family ipv4 unicast ; no redistribute kernel',

--- a/templates/protocols/bgp/node.tag/address-family/ipv4-unicast/redistribute/isis/metric/node.def
+++ b/templates/protocols/bgp/node.tag/address-family/ipv4-unicast/redistribute/isis/metric/node.def
@@ -1,0 +1,2 @@
+type: u32
+help: Metric for redistributed routes

--- a/templates/protocols/bgp/node.tag/address-family/ipv4-unicast/redistribute/isis/node.def
+++ b/templates/protocols/bgp/node.tag/address-family/ipv4-unicast/redistribute/isis/node.def
@@ -1,0 +1,1 @@
+help: Redistribute IS-IS routes into BGP

--- a/templates/protocols/bgp/node.tag/address-family/ipv4-unicast/redistribute/isis/route-map/node.def
+++ b/templates/protocols/bgp/node.tag/address-family/ipv4-unicast/redistribute/isis/route-map/node.def
@@ -1,0 +1,6 @@
+type: txt
+help: Route map to filter redistributed routes
+allowed: local -a params
+        params=$( /opt/vyatta/sbin/vyatta-policy.pl --list-policy route-map )
+        echo -n ${params[@]##*/}
+commit:expression: exec "/opt/vyatta/sbin/vyatta_quagga_utils.pl --exists \"policy route-map $VAR(@)\" ";"route-map $VAR(@) doesn't exist"

--- a/templates/protocols/ospf/access-list/node.tag/export/node.def
+++ b/templates/protocols/ospf/access-list/node.tag/export/node.def
@@ -1,10 +1,11 @@
 multi:
 type: txt
 help: Filter for outgoing routing updates [REQUIRED]
-syntax:expression: $VAR(@) in "bgp", "connected", "kernel", "rip", "static"; "Must be (bgp, connected, kernel, rip, or static)"
+syntax:expression: $VAR(@) in "bgp", "connected", "isis", "kernel", "rip", "static"; "Must be (bgp, connected, isis, kernel, rip, or static)"
 
 val_help: bgp                Filter bgp routes; 
 val_help: connected          Filter connected routes; 
+val_help: isis               Filter IS-IS routes;
 val_help: kernel             Filter kernel routes; 
 val_help: rip                Filter rip routes; 
 val_help: static             Filter static routes; 

--- a/templates/protocols/ospf/redistribute/isis/metric-type/node.def
+++ b/templates/protocols/ospf/redistribute/isis/metric-type/node.def
@@ -1,0 +1,5 @@
+type: u32
+help: OSPF metric type
+default: 2
+syntax:expression: $VAR(@) in 1, 2 ; "metric-type must be either 1 or 2"
+val_help: u32:1-2; Metric type (default 2)

--- a/templates/protocols/ospf/redistribute/isis/metric/node.def
+++ b/templates/protocols/ospf/redistribute/isis/metric/node.def
@@ -1,0 +1,4 @@
+type: u32
+help: Metric for redistributed routes
+syntax:expression: $VAR(@) >= 0 && $VAR(@) <= 16777214; "metric must be between 0 and 16777214"
+val_help: u32:0-16777214; Metric for redistributed routes

--- a/templates/protocols/ospf/redistribute/isis/node.def
+++ b/templates/protocols/ospf/redistribute/isis/node.def
@@ -1,0 +1,21 @@
+help: Redistribute IS-IS routes
+delete:expression: "touch /tmp/ospf-redist-isis.$PPID"
+end: vtysh -c "configure terminal"    \
+        -c "router ospf"                                          \
+        -c "no redistribute isis";
+     if [ -f "/tmp/ospf-redist-isis.$PPID" ]; then
+        rm -f /tmp/ospf-redist-isis.$PPID;
+     else
+        if [ -n "$VAR(./metric/@)" ]; then
+           COND="metric $VAR(./metric/@)";
+        fi;
+	if [ -n "$VAR(./metric-type/@)" ]; then
+	   COND="$COND metric-type $VAR(./metric-type/@)";
+        fi;
+        if [ -n "$VAR(./route-map/@)" ]; then
+           COND="$COND route-map $VAR(./route-map/@)";
+        fi;
+        vtysh -c "configure terminal" \
+           -c "router ospf"                                       \
+           -c "redistribute isis $COND";
+     fi;

--- a/templates/protocols/ospf/redistribute/isis/route-map/node.def
+++ b/templates/protocols/ospf/redistribute/isis/route-map/node.def
@@ -1,0 +1,3 @@
+type: txt
+help: Route map reference
+commit:expression: exec "/opt/vyatta/sbin/vyatta_quagga_utils.pl --exists \"policy route-map $VAR(@)\" ";"route-map $VAR(@) doesn't exist"


### PR DESCRIPTION
Add option for redistribute protocol IS-IS into bgp/ospf

VyOS config
```
set protocols bgp 65530 address-family ipv4-unicast redistribute isis
set protocols bgp 65530 neighbor 100.64.0.2 remote-as '65002'
set protocols ospf redistribute isis
```
FRR
```
!
router bgp 65530
 neighbor 100.64.0.2 remote-as 65002
 !
 address-family ipv4 unicast
  redistribute isis
 exit-address-family
!
router ospf
 redistribute isis
!

```