### PR TITLE
route-map: T3306: Extend aggregator as to 4 byte

### DIFF
--- a/templates/policy/route-map/node.tag/rule/node.tag/set/aggregator/as/node.def
+++ b/templates/policy/route-map/node.tag/rule/node.tag/set/aggregator/as/node.def
@@ -1,5 +1,5 @@
 type: u32
 help: AS number of an aggregation
-val_help: u32:1-65535; BGP AS number
+val_help: u32:1-4294967295; BGP AS number
 
-syntax:expression: $VAR(@) >= 1 && $VAR(@) <= 4294967294; "BGP AS number must be between 1 and 4294967294"
+syntax:expression: $VAR(@) >= 1 && $VAR(@) <= 4294967295; "BGP AS number must be between 1 and 4294967295"


### PR DESCRIPTION
Extend route-map aggregator as to 4 bytes, fix value help
VyOS config:
```
set policy route-map FOO rule 10 action 'permit'
set policy route-map FOO rule 10 set aggregator as '4294967295'
set policy route-map FOO rule 10 set aggregator ip '203.0.113.1'
```
FRR config:
```
!
route-map FOO permit 10
 set aggregator as 4294967295 203.0.113.1
!

```