### PR TITLE
route-map: T3190: Add ability to add and substr local-preference

### DIFF
--- a/templates/policy/route-map/node.tag/rule/node.tag/set/local-preference/node.def
+++ b/templates/policy/route-map/node.tag/rule/node.tag/set/local-preference/node.def
@@ -1,7 +1,9 @@
-type: u32
+type: txt
 help: Border Gateway Protocol (BGP) local preference attribute
-val_help: Local preference value
+val_help: u32:0-4294967295; Local preference value
+val_help: <+/-local-preference>; Add or subtract local-preference
 
+syntax:expression: exec "if [ -n \"$(echo $VAR(@) | sed 's/^[+-]*[0123456789]*//')\" ]; then exit 1; fi; "; "local-preferemce must be an integer with an optional +/- prepend"
 commit:expression: $VAR(../../action/) != ""; "you must specify an action"
 
 update: vtysh -c "configure terminal" \


### PR DESCRIPTION
Ability to set "add and subtract" for route-map local-preference value

* https://phabricator.vyos.net/T3190

VyOS config

```
set policy route-map FOO rule 10 action 'permit'
set policy route-map FOO rule 10 set local-preference '+25'

```
FRR config
```
!
route-map FOO permit 10
 set local-preference +25
!

```