### PR TITLE
route-map: T3032: Crux Add set table x for route-map

### DIFF
--- a/templates/policy/route-map/node.tag/rule/node.tag/set/table/node.def
+++ b/templates/policy/route-map/node.tag/rule/node.tag/set/table/node.def
@@ -1,0 +1,14 @@
+type: u32
+help: Set prefixes to table
+val_help: u32:1-200; Table value
+
+syntax:expression: $VAR(@) >= 1 && $VAR(@) <= 200; "table must be between 1 and 200"
+commit:expression: $VAR(../../action/) != ""; "you must specify an action"
+
+update: vtysh -c "configure terminal" \
+         -c "route-map $VAR(../../../@) $VAR(../../action/@) $VAR(../../@)" \
+         -c "set table $VAR(@)"
+
+delete: vtysh -c "configure terminal" \
+         -c "route-map $VAR(../../../@) $VAR(../../action/@) $VAR(../../@)" \
+         -c "no set table "


### PR DESCRIPTION
Crux.
Ability to set prefixes for a specific table in the route-map.

VyOS config.
```
set policy route-map FOO rule 10 action 'permit'
set policy route-map FOO rule 10 set table '120'
set protocols bgp 65001 neighbor 192.168.122.14 address-family ipv4-unicast route-map import 'FOO'
set protocols bgp 65001 neighbor 192.168.122.14 remote-as '65002'

```
Check
```
vyos@r2-lts:~$ show ip route table 120
Codes: K - kernel route, C - connected, S - static, R - RIP,
       O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
       F - PBR, f - OpenFabric,
       > - selected route, * - FIB route, q - queued route, r - rejected route

VRF default table 120:
B>* 192.0.2.0/24 [20/0] via 192.168.122.14, eth0, 00:00:36
B>* 203.0.113.0/24 [20/0] via 192.168.122.14, eth0, 00:00:36

```