### PR TITLE
bgp: T2100: Add global param for ebgp-policy

### DIFF
--- a/templates/protocols/bgp/node.def
+++ b/templates/protocols/bgp/node.def
@@ -8,6 +8,12 @@ syntax:expression: $VAR(@) >= 1 && $VAR(@) <= 4294967294 ; \
 		   "AS number must be between 1 and 4294967294"
 
 end: if [ -z "$VAR(.)" ] || [ "$COMMIT_ACTION" != DELETE ]; then
+       vtysh -d bgpd -c 'conf t' -c 'router bgp $VAR(@)' -c 'no bgp ebgp-requires-policy'
+
+       if [ -z $VAR(./parameters/network-import-check/) ]; then
+         vtysh -d bgpd -c 'conf t' -c 'router bgp $VAR(@)' -c 'no bgp network import-check'
+       fi
+
        /opt/vyatta/sbin/vyatta-bgp.pl --main
        vtysh -d bgpd -c 'sh run' > /opt/vyatta/etc/quagga/bgpd.conf
      else


### PR DESCRIPTION
For the update to FRR 7.5 and get behavior 7.3 we need to set 2 default parameters for section bgp.
```
 no bgp ebgp-requires-policy
 no bgp network import-check
```
As we don't have any default values for bgp in PERL we can set it in " templates/protocols/bgp/node.def"
These parameters should be before "/opt/vyatta/sbin/vyatta-bgp.pl --main"

This PR required update FRR to 7.5. https://github.com/vyos/vyos-build/pull/163

VyOS config
```
set protocols bgp 65001 neighbor 10.0.0.2 remote-as '65002'
set protocols bgp 65001 neighbor 10.0.0.3 remote-as '65003'
```
Expected config  "no bgp ebgp-requires-policy", "no bgp network import-check" + 2 neighbors
```
!
router bgp 65001
 no bgp ebgp-requires-policy
 no bgp network import-check
 neighbor 10.0.0.2 remote-as 65002
 neighbor 10.0.0.3 remote-as 65003
!
line vty
!
```
Set network-import-check
```
set protocols bgp 65001 parameters network-import-check
```
Expected config
```
!
router bgp 65001
 no bgp ebgp-requires-policy
 neighbor 10.0.0.2 remote-as 65002
 neighbor 10.0.0.3 remote-as 65003
!
line vty
!

```
Tested on 1.3 + FRR 7.5.1
```
vyos@r4-1.3# run show version 

Version:          VyOS 1.3-rolling-202104261604
Release Train:    equuleus

Built by:         v.gletenko@vyos.io
Built on:         Mon 26 Apr 2021 16:04 UTC
Build UUID:       c3bc9b50-8025-49b1-a48e-9c0aebda2d58
Build Commit ID:  470b2d00790a82-dirty

Architecture:     x86_64
Boot via:         installed image
System type:      KVM guest

vyos@r4-1.3# 
[edit]
vyos@r4-1.3# run show version all | match frr
ii  frr                                  7.5.1-20210426-00-g66ef8f7bf-0      amd64        FRRouting suite of internet protocols (BGP, OSPF, IS-IS, ...)
ii  frr-dbgsym                           7.5.1-20210426-00-g66ef8f7bf-0      amd64        debug symbols for frr
ii  frr-doc                              7.5.1-20210426-00-g66ef8f7bf-0      all          FRRouting suite - user manual
ii  frr-pythontools                      7.5.1-20210426-00-g66ef8f7bf-0      all          FRRouting suite - Python tools
ii  frr-rpki-rtrlib                      7.5.1-20210426-00-g66ef8f7bf-0      amd64        FRRouting suite - BGP RPKI support (rtrlib)
ii  frr-rpki-rtrlib-dbgsym               7.5.1-20210426-00-g66ef8f7bf-0      amd64        debug symbols for frr-rpki-rtrlib
ii  frr-snmp                             7.5.1-20210426-00-g66ef8f7bf-0      amd64        FRRouting suite - SNMP support
ii  frr-snmp-dbgsym                      7.5.1-20210426-00-g66ef8f7bf-0      amd64        debug symbols for frr-snmp

```
Smoktetests
```
vyos@r4-1.3:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_bgp.py
test_bgp_01_simple (__main__.TestProtocolsBGP) ... ok
test_bgp_02_neighbors (__main__.TestProtocolsBGP) ... ok
test_bgp_03_peer_groups (__main__.TestProtocolsBGP) ... ok
test_bgp_04_afi_ipv4 (__main__.TestProtocolsBGP) ... ok
test_bgp_05_afi_ipv6 (__main__.TestProtocolsBGP) ... ok

----------------------------------------------------------------------
Ran 5 tests in 23.793s

OK

```

