### PR TITLE
frr: T3217: Ability to save routing configs

### DIFF
--- a/templates/protocols/bgp/node.def
+++ b/templates/protocols/bgp/node.def
@@ -10,6 +10,7 @@ syntax:expression: $VAR(@) >= 1 && $VAR(@) <= 4294967294 ; \
 end: if [ -z "$VAR(.)" ] || [ "$COMMIT_ACTION" != DELETE ]; then
        /opt/vyatta/sbin/vyatta-bgp.pl --main
        vtysh -d bgpd -c 'sh run' > /opt/vyatta/etc/quagga/bgpd.conf
+       sudo vtysh --writeconfig --noerror
      else
        rm -f /opt/vyatta/etc/quagga/bgpd.conf
      fi

--- a/templates/protocols/ospf/node.def
+++ b/templates/protocols/ospf/node.def
@@ -15,4 +15,5 @@ end: if [ "$COMMIT_ACTION" == DELETE ]; then
        rm -f /opt/vyatta/etc/quagga/ospfd.conf
      else
        vtysh -d ospfd -c 'sh run' > /opt/vyatta/etc/quagga/ospfd.conf
+       sudo vtysh --writeconfig --noerror
      fi

--- a/templates/protocols/ospfv3/node.def
+++ b/templates/protocols/ospfv3/node.def
@@ -9,6 +9,7 @@ begin: if [ "$COMMIT_ACTION" != DELETE ]; then
                  -c "no ospf6 router-id"
          fi
          vtysh -d ospf6d -c 'sh run' > /opt/vyatta/etc/quagga/ospf6d.conf
+         sudo vtysh --writeconfig --noerror
        fi
 end: if [ "$COMMIT_ACTION" == DELETE ]; then
        vtysh -c "configure terminal" -c "router ospf6" -c "no router-id"

--- a/templates/protocols/ripng/node.def
+++ b/templates/protocols/ripng/node.def
@@ -5,6 +5,7 @@ delete: vtysh -c "configure terminal" -c "no router ripng"
 end:
   if [ "$COMMIT_ACTION" != "DELETE" ]; then
     vtysh -d ripngd -c 'sh run' > /opt/vyatta/etc/quagga/ripngd.conf
+    sudo vtysh --writeconfig --noerror
   else
     rm -f /opt/vyatta/etc/quagga/ripngd.conf
   fi

--- a/templates/protocols/static/node.def
+++ b/templates/protocols/static/node.def
@@ -3,6 +3,7 @@ help: Static route parameters
 end:
   if [ "$COMMIT_ACTION" != "DELETE" ]; then
     vtysh -d zebra -c 'sh run' > /opt/vyatta/etc/quagga/zebra.conf
+    sudo vtysh --writeconfig --noerror
   else
     rm -f /opt/vyatta/etc/quagga/zebra.conf
   fi


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Ability to save routing configs. For 1.3

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3217

Related PR
https://github.com/vyos/vyatta-cfg/pull/39

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
frr

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Add routing configuration and restart or kill routing daemon
```
set protocols bgp 65001 neighbor 203.0.113.2 remote-as '65003'
set protocols ospf redistribute static
set protocols static route 0.0.0.0/0 next-hop 192.168.122.1
```
Restart bgpd
```
/usr/lib/frr/watchfrr.sh restart bgpd
```
Check config after restart. Neighbor should be configured.
```
vyos@r4-1.3# run show ip bgp sum | grep "Neighb" -A 5
Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd   PfxSnt
203.0.113.2     4      65003         0         0        0    0    0    never       Active        0

Total number of neighbors 1
[edit]
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
