### PR TITLE
staticd: T3516: Fix for static routes for FRR-7.5.1

### DIFF
--- a/templates/protocols/static/interface-route/node.tag/next-hop-interface/node.def
+++ b/templates/protocols/static/interface-route/node.tag/next-hop-interface/node.def
@@ -14,7 +14,10 @@ end:
       if ! ${vyatta_sbindir}/vyatta-next-hop-check $VAR(../@) ipv4 interface; then
         exit 1;
       fi
+      DIST=`cli-shell-api returnEffectiveValue protocols static interface-route $VAR(../@) next-hop-interface $VAR(@) distance`
+
       vtysh -c "configure terminal" \
+                   -c "no ip route $VAR(../@) $VAR(@) $DIST" \
                    -c "no ip route $VAR(../@) $VAR(@)"
     else
       if [[ -n "$VAR(./distance/@)" ]]; then
@@ -23,6 +26,23 @@ end:
       if [[ -n "$VAR(./next-hop-vrf/@)" ]]; then
          NEXTHOP_VRF="nexthop-vrf $VAR(./next-hop-vrf/@)"
       fi
+
+      # T3516
+      # FRR 7.5.1 use routes as multinode, VyOS as single-node
+      # ip route 203.0.113.0/24 dum08765
+      # ip route 203.0.113.0/24 dum08765 10
+      # ip route 203.0.113.0/24 dum08765 254
+      # So we need remove old frr routes before adding new.
+      # $VAR(../@) = 203.0.113.0/24
+      # $VAR(@) = dum08765
+
+      data=`vtysh -c "show run staticd no-header" | grep -P "^ip route $VAR(../@) $VAR(@)( \d+){0,1}$"`
+      IFS=$'\n' read -d '' -a old_routes <<< ${data}
+      for ROUTE in "${old_routes[@]}"
+        do
+          vtysh -c "conf t" -c "no $ROUTE"
+        done
+
       vtysh -c "configure terminal" \
             -c "ip route $VAR(../@) $VAR(@) $NEXTHOP_VRF $DIST";
     fi

--- a/templates/protocols/static/route/node.tag/next-hop/node.def
+++ b/templates/protocols/static/route/node.tag/next-hop/node.def
@@ -16,16 +16,35 @@ end:
       if ! ${vyatta_sbindir}/vyatta-next-hop-check $VAR(../@) ipv4 address; then
         exit 1;
       fi
+      DIST=`cli-shell-api returnEffectiveValue protocols static route $VAR(../@) next-hop $VAR(@) distance`
       if ${vyatta_sbindir}/vyatta-gateway-static_route-check.pl \
           "$VAR(../@)" "$VAR(@)"
       then
         vtysh -c "configure terminal" \
+                     -c "no ip route $VAR(../@) $VAR(@) $DIST" \
                      -c "no ip route $VAR(../@) $VAR(@)"
       fi
     else
       if [ -n "$VAR(./next-hop-vrf/@)" ]; then 
           NEXTHOP_VRF="nexthop-vrf $VAR(./next-hop-vrf/@)"
       fi
+
+      # T3516
+      # FRR 7.5.1 use routes as multinode, VyOS as single-node
+      # ip route 203.0.113.0/24 10.0.0.1
+      # ip route 203.0.113.0/24 10.0.0.1 10
+      # ip route 203.0.113.0/24 10.0.0.1 254
+      # So we need remove old frr routes before adding new.
+      # $VAR(../@) = 203.0.113.0/24
+      # $VAR(@) = 10.0.0.1
+
+      data=`vtysh -c "show run staticd no-header" | grep -P "^ip route $VAR(../@) $VAR(@)( \d+){0,1}$"`
+      IFS=$'\n' read -d '' -a old_routes <<< ${data}
+      for ROUTE in "${old_routes[@]}"
+        do
+          vtysh -c "conf t" -c "no $ROUTE"
+        done
+
       vtysh -c "configure terminal" \
                    -c "ip route $VAR(../@) $VAR(@) $VAR(./next-hop-interface/@) $NEXTHOP_VRF $VAR(./distance/@)";
     fi


### PR DESCRIPTION
Fix for static routes for FRR 7.5.1
It use multinode values for the same route with different distance

https://phabricator.vyos.net/T3516

How to test.
VyOS config
```
set protocols static route 203.0.113.0/24 next-hop 10.0.0.1
commit
set protocols static route 203.0.113.0/24 next-hop 10.0.0.1 distance 5
commit
set protocols static route 203.0.113.0/24 next-hop 10.0.0.1 distance 10
commit
```
Expected only one route in FRR
```
!
ip route 203.0.113.0/24 10.0.0.1 10
!

```
Because we use one value for same route with different distance
```
vyos@r4-1.3# show protocols 
 static {
     route 203.0.113.0/24 {
         next-hop 10.0.0.1 {
             distance 10
         }
     }
 }

```
Smoketest
```
root@r4-1:/home/vyos# /usr/libexec/vyos/tests/smoke/cli/test_protocols_static.py
test_interface_routes (__main__.StaticRouteTest) ... ok
test_static_routes (__main__.StaticRouteTest) ... ok

----------------------------------------------------------------------
Ran 2 tests in 7.454s

OK

```
