### PR TITLE
policy: T3528: Fix seq for community lists

### DIFF
--- a/scripts/policy/vyatta-policy.pl
+++ b/scripts/policy/vyatta-policy.pl
@@ -116,7 +116,7 @@ sub update_large_community_list {
         if (!($regex =~ /(.*):(.*):(.*)/) and (isIpAddress($1)or($1=~/^\d+$/) ) and ($2=~/^\d+$/)) {
               die "large-community-list $name rule $rule: Malformed large-community-list regex";
         }
-        system("$VTYSH -c \"conf t\" -c \"bgp large-community-list expanded $name $action $regex\"");
+        system("$VTYSH -c \"conf t\" -c \"bgp large-community-list expanded $name seq $rule $action $regex\"");
     }
 
     exit(0);
@@ -153,7 +153,7 @@ sub update_ext_community_list {
         if (!($regex =~ /(.*):(.*)/) and (isIpAddress($1)or($1=~/^\d+$/) ) and ($2=~/^\d+$/)) {
               die "extcommunity-list $name rule $rule: Malformed extcommunity-list regex";
         }
-        system("$VTYSH -c \"conf t\" -c \"bgp extcommunity-list expanded $name $action $regex\"");
+        system("$VTYSH -c \"conf t\" -c \"bgp extcommunity-list expanded $name seq $rule $action $regex\"");
     }
 
     exit(0);
@@ -187,7 +187,7 @@ sub update_community_list {
           unless $regex;
 
         system(
-"$VTYSH -c \"configure terminal\" -c \"bgp community-list expanded $num $action $regex\" "
+"$VTYSH -c \"configure terminal\" -c \"bgp community-list expanded $num seq $rule $action $regex\" "
         );
     }
 


### PR DESCRIPTION
Task https://phabricator.vyos.net/T3528
Frr 7.5.1 by default use "seq x" for policy community lists.
Fix order of seq

VyOS config
```
set policy community-list 100 rule 1 action 'permit'
set policy community-list 100 rule 1 regex '11:121'
set policy community-list 100 rule 2 action 'permit'
set policy community-list 100 rule 2 regex '22:222'
set policy community-list 100 rule 3 action 'permit'
set policy community-list 100 rule 3 regex '33:323'
set policy community-list 100 rule 4 action 'deny'
set policy community-list 100 rule 4 regex '.*'
set policy extcommunity-list FFF rule 2 action 'permit'
set policy extcommunity-list FFF rule 2 regex '44:22:22'
set policy extcommunity-list FFF rule 10 action 'permit'
set policy extcommunity-list FFF rule 10 regex '44:55:33'

```
Frr config. Expect that  "rule" will be matched with "seq"
```
!
bgp community-list 100 seq 1 permit 11:121
bgp community-list 100 seq 2 permit 22:222
bgp community-list 100 seq 3 permit 33:323
bgp community-list 100 seq 4 deny .*
bgp extcommunity-list expanded FFF seq 2 permit 44:22:22
bgp extcommunity-list expanded FFF seq 10 permit 44:55:33
!
line vty
!

```
