### PR TITLE
conf-mode:T3558:Fix for static route dhcp-interface options

### DIFF
--- a/templates/protocols/static/route/node.tag/dhcp-interface/node.def
+++ b/templates/protocols/static/route/node.tag/dhcp-interface/node.def
@@ -1,9 +1,8 @@
 type: txt
-help: DHCP interface that supplies the next-hop IP address for this static route
-allowed:
-        local -a array ;
-        array=( /var/lib/dhcp/en* /var/lib/dhcp/eth* /var/lib/dhcp/br* /var/lib/dhcp/bond* ) ;
-        echo  -n ${array[@]##*/}
+help: DHCP interface supplying next-hop IP address
+val_help: txt; DHCP interface name
+allowed: sh -c "${vyos_completion_dir}/list_interfaces.py"
+syntax:expression: exec "${vyos_libexec_dir}/validate-value  --exec \"${vyos_validators_dir}/interface-name \" --value \'$VAR(@)\'"; "Invalid value"
 create:
         sudo /opt/vyatta/sbin/vyatta-update-static-route.pl --interface=$VAR(@) --route=$VAR(../@) --table=main --option=create
         RIP=$(/opt/vyatta/sbin/vyatta-dhcp-helper.pl --interface=$VAR(@) --want=router)


### PR DESCRIPTION


The command "set protocols static route x.x.x.x/x dhcp-interface" does not show
the possible interface list when entered a tab.