### PR TITLE
route-map: T3605: Allow to set prefer-global for ipv6-next-hop

### DIFF
--- a/templates/policy/route-map/node.tag/rule/node.tag/set/ipv6-next-hop/prefer-global/node.def
+++ b/templates/policy/route-map/node.tag/rule/node.tag/set/ipv6-next-hop/prefer-global/node.def
@@ -1,0 +1,12 @@
+help: Prefer global address as the nexthop
+
+commit:expression: $VAR(../../../action/) != ""; "you must specify an action"
+
+update: vtysh -c "configure terminal" \
+         -c "route-map $VAR(../../../../@) $VAR(../../../action/@) $VAR(../../../@)" \
+         -c "set ipv6 next-hop prefer-global"
+
+delete: vtysh -c "configure terminal" \
+         -c "route-map $VAR(../../../../@) $VAR(../../../action/@) $VAR(../../../@)" \
+         -c "no set ipv6 next-hop prefer-global"
+


### PR DESCRIPTION
When we receive a global and link-local ipv6 next-hop ipv6 address,
normally the link-local one is preferred. This setting allows to use the
global ipv6 instead. This is required if the peer does not answer on
his link-local address.

https://docs.frrouting.org/en/latest/routemap.html#clicmd-setipv6next-hopprefer-global