### PR TITLE
route-map: T3632: fix invalid validation regex for extcommunity-rt and extcommunity-soo

### DIFF
--- a/templates/policy/route-map/node.tag/rule/node.tag/set/extcommunity-rt/node.def
+++ b/templates/policy/route-map/node.tag/rule/node.tag/set/extcommunity-rt/node.def
@@ -1,8 +1,10 @@
 type: txt
 help: Set route target value
-val_help: ASN:nn_or_IP_address:nn VPN extended community
+val_help: ASN:NN; based on autonomous system number
+val_help: IP:NN; Based on a router-id IP address
 
-syntax:expression: pattern $VAR(@) "\d+:\d+(\.\d+\.\d+\.\d+):\d+" ; "Should be in form: ASN:nn_or_IP_address:nn where ASN is autonomous system number" 
+syntax:expression: exec "${vyos_libexec_dir}/validate-value --regex \'^((?:[0-9]{1,3}\\.){3}[0-9]{1,3}|\\d+):\\d+$\'  --value \'$VAR(@)\'"; "Should be in form: ASN:NN or IPADDR:NN where ASN is autonomous system number"
+
 commit:expression: $VAR(../../action/) != ""; "you must specify an action"
 
 update: vtysh -c "configure terminal" \

--- a/templates/policy/route-map/node.tag/rule/node.tag/set/extcommunity-soo/node.def
+++ b/templates/policy/route-map/node.tag/rule/node.tag/set/extcommunity-soo/node.def
@@ -1,8 +1,10 @@
 type: txt
-help: Set Site of Origin value. 
-val_help: ASN:nn_or_IP_address:nn VPN extended community
+help: Set Site of Origin value.
+val_help: ASN:NN; based on autonomous system number
+val_help: IP:NN; Based on a router-id IP address
 
-syntax:expression: pattern $VAR(@) "\d+:\d+(\.\d+\.\d+\.\d+):\d+" ; "Should be in form: ASN:nn_or_IP_address:nn where ASN is autonomous system number" 
+syntax:expression: exec "${vyos_libexec_dir}/validate-value --regex \'^((?:[0-9]{1,3}\\.){3}[0-9]{1,3}|\\d+):\\d+$\'  --value \'$VAR(@)\'"; "Should be in form: ASN:NN or IPADDR:NN where ASN is autonomous system number"
+
 commit:expression: $VAR(../../action/) != ""; "you must specify an action"
 
 update: vtysh -c "configure terminal" \


### PR DESCRIPTION
Use the validation string/system available within vyos-1x. This also
works also on VyOS 1.2 series systems.

(cherry picked from commit 2c6ec4330384606fb25b8afb5ef1831320715917)

VyOS 1.3 and later systems use `validate-value` without extension, hence the difference to the PR for `crux` branch in #82 