### PR TITLE
frr: T3689: Fix for static route6

### DIFF
--- a/templates/protocols/static/route6/node.tag/next-hop/node.def
+++ b/templates/protocols/static/route6/node.tag/next-hop/node.def
@@ -4,6 +4,13 @@ help: Next-hop IPv6 router [REQUIRED]
 end:
   if [[ -z "$VAR(./disable)" ]]
   then
+    ### remove the old entry from frr first on an update
+    if [ ${COMMIT_ACTION} = 'ACTIVE' ]
+      then
+        OLD_IF=`cli-shell-api returnEffectiveValue protocols static route6 $VAR(../@) next-hop $VAR(@) interface`
+        vtysh -c "configure terminal" \
+              -c "no ipv6 route $VAR(../@) $VAR(@) $OLD_IF $VAR(./distance/@)";
+    fi
     if [[ ${COMMIT_ACTION} = 'DELETE' ]]
     then
       if ! ${vyatta_sbindir}/vyatta-next-hop-check $VAR(../@) ipv6 address; then


### PR DESCRIPTION
Fix for Replace static ipv6 routes. Without fix, it add an additional static ipv6 route

Without fix:
```
set protocols static route6 ::/0 next-hop fe80::11
commit
set protocols static route6 ::/0 next-hop fe80::11 interface eth0
commit

vyos@r4-1.3# vtysh -c "show run | include ipv"
ipv6 route ::/0 fe80::11 eth0
ipv6 route ::/0 fe80::11

vyos@r4-1.3# delete protocols 
[edit]
vyos@r4-1.3# commit
[edit]
vyos@r4-1.3# vtysh -c "show run | include ipv"
ipv6 route ::/0 fe80::11
[edit]
```
With fix:
```

set protocols static route6 ::/0 next-hop fe80::11
commit
set protocols static route6 ::/0 next-hop fe80::11 interface eth0
commit

vyos@r4-1.3# vtysh -c "show run | include ipv"
ipv6 route ::/0 fe80::11 eth0

vyos@r4-1.3# vtysh -c "show run | include ipv"
ipv6 route ::/0 fe80::11 eth0
[edit]
vyos@r4-1.3# 
[edit]
vyos@r4-1.3# delete protocols 
[edit]
vyos@r4-1.3# commit
[edit]
vyos@r4-1.3# 
[edit]
vyos@r4-1.3# vtysh -c "show run | include ipv"
[edit]
vyos@r4-1.3# 

```


https://phabricator.vyos.net/T3689