### PR TITLE
frr: T3685: Add interface option for static table route6

### DIFF
--- a/templates/protocols/static/table/node.tag/route6/node.tag/next-hop/node.def
+++ b/templates/protocols/static/table/node.tag/route6/node.tag/next-hop/node.def
@@ -11,6 +11,14 @@ end:
   fi
   if [[ -z "$VAR(./disable)" ]]
   then
+    ### remove the old entry from frr first on an update
+    if [ ${COMMIT_ACTION} = 'ACTIVE' ]
+      then
+        OLD_IF=`cli-shell-api returnEffectiveValue protocols static $table route6 $VAR(../@) next-hop $VAR(@) interface`
+        vtysh -c "configure terminal" \
+              -c "no ipv6 route $VAR(../@) $VAR(@) $OLD_IF $VAR(./distance/@) $table";
+    fi
+
     if [[ ${COMMIT_ACTION} = 'DELETE' ]]
     then
       if ! ${vyatta_sbindir}/vyatta-next-hop-check $VAR(../@) ipv6 address; then
@@ -19,8 +27,10 @@ end:
       if ${vyatta_sbindir}/vyatta-gateway-static_route-check.pl \
           "$VAR(../@)" "$VAR(@)"
       then
+        DIST=`cli-shell-api returnEffectiveValue protocols static $table route6 $VAR(../@) next-hop $VAR(@) distance`
+        INTERFACE=`cli-shell-api returnEffectiveValue protocols static $table route6 $VAR(../@) next-hop $VAR(@) interface`
         vtysh -c "configure terminal" \
-                     -c "no ipv6 route $VAR(../@) $VAR(@) $table"
+                     -c "no ipv6 route $VAR(../@) $VAR(@) $INTERFACE $DIST $table";
       fi
     else
       if [[ -n "$VAR(./distance/@)" ]]
@@ -28,8 +38,12 @@ end:
         DIST="$VAR(./distance/@)"
       fi
 
+      if [[ -n "$VAR(./interface/@)" ]]; then
+        INTERFACE="$VAR(./interface/@)"
+      fi
+
       vtysh -c "configure terminal" \
-                   -c "ipv6 route $VAR(../@) $VAR(@) $table $DIST";
+                   -c "ipv6 route $VAR(../@) $VAR(@) $INTERFACE $DIST $table";
     fi
   else
     if ${vyatta_sbindir}/vyatta-gateway-static_route-check.pl \

--- a/templates/protocols/static/table/node.tag/route6/node.tag/next-hop/node.tag/interface/node.def
+++ b/templates/protocols/static/table/node.tag/route6/node.tag/next-hop/node.tag/interface/node.def
@@ -1,0 +1,6 @@
+type: txt
+help: IPv6 gateway interface name
+# show all current interface
+# but syntax accepts any interface since it may exist later (ppp etc)
+allowed: ${vyatta_sbindir}/vyatta-interfaces.pl --show all
+


### PR DESCRIPTION
Add option "interface" for ipv6 static routes.
It allows more flexible to set routes.

https://phabricator.vyos.net/T3685

For example in that case the route assigned to the loopback interface
```
set protocols static table 1 route6 ::/0 next-hop fe80::11
commit

vyos@r4-1.3# run show ipv6 route table 1 | match 0
S>* ::/0 [1/0] via fe80::11, lo, weight 1, 00:01:26
[edit]
vyos@r4-1.3# 
```
With this feature.
```
set protocols static table 1 route6 ::/0 next-hop fe80::11 interface eth0
commit

vyos@r4-1.3# run show ipv6 route table 1 | match "0"
S>* ::/0 [1/0] via fe80::11, eth0, weight 1, 00:00:57
[edit]
vyos@r4-1.3# 
```
