### PR TITLE
bgp: T1176: Add option solo for neighbor

### DIFF
--- a/scripts/bgp/vyatta-bgp.pl
+++ b/scripts/bgp/vyatta-bgp.pl
@@ -606,6 +606,10 @@ my %qcom = (
       set => 'router bgp #3 ; neighbor #5 passive',
       del => 'router bgp #3 ; no neighbor #5 passive',
   },
+  'protocols bgp var neighbor var solo' => {
+      set => 'router bgp #3 ; neighbor #5 solo',
+      del => 'router bgp #3 ; no neighbor #5 solo',
+  },
   'protocols bgp var neighbor var bfd' => {
       set => 'router bgp #3 ; neighbor #5 bfd',
       del => 'router bgp #3 ; no neighbor #5 bfd',

--- a/templates/protocols/bgp/node.tag/neighbor/node.tag/solo/node.def
+++ b/templates/protocols/bgp/node.tag/neighbor/node.tag/solo/node.def
@@ -1,0 +1,1 @@
+help: Do not send back prefixes learned from the neighbor


### PR DESCRIPTION
Add bgp option "solo" for neighbor.
It prevents sending routes back to ebgp neighbor, from which this prefix was received.
https://phabricator.vyos.net/T1176

Before option "solo"
```
Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd   PfxSnt
203.0.113.1     4      65001        83        87        0    0    0 01:18:12            3        3

vyos@r4-1.3:~$ show ip bgp neighbors 203.0.113.1 routes | match 100
Default local pref 100, local AS 65002
*> 100.64.0.0/24    203.0.113.1              0             0 65001 i
*> 100.64.1.0/24    203.0.113.1              0             0 65001 i
*> 100.64.2.0/24    203.0.113.1              0             0 65001 i
vyos@r4-1.3:~$ 
      
vyos@r4-1.3:~$ show ip bgp neighbors 203.0.113.1 advertised-routes | match 100
Default local pref 100, local AS 65002
*> 100.64.0.0/24    0.0.0.0                                0 65001 i
*> 100.64.1.0/24    0.0.0.0                                0 65001 i
*> 100.64.2.0/24    0.0.0.0                                0 65001 i
vyos@r4-1.3:~$ 
```
With option solo:
```
vyos@r4-1.3:~$ conf
[edit]
vyos@r4-1.3# set protocols bgp 65002 neighbor 203.0.113.1 solo 
[edit]
vyos@r4-1.3# commit
[edit]
vyos@r4-1.3# 
vyos@r4-1.3# run show ip bgp neighbors 203.0.113.1 advertised-routes | match 100
[edit]
vyos@r4-1.3# 

```