### PR TITLE
ospfv3: T3858: Fix for delete correct v6 router-id

### DIFF
--- a/templates/protocols/ospfv3/node.def
+++ b/templates/protocols/ospfv3/node.def
@@ -12,6 +12,6 @@ begin: if [ "$COMMIT_ACTION" != DELETE ]; then
          sudo vtysh --writeconfig --noerror
        fi
 end: if [ "$COMMIT_ACTION" == DELETE ]; then
-       vtysh -c "configure terminal" -c "router ospf6" -c "no router-id"
+       vtysh -c "configure terminal" -c "router ospf6" -c "no ospf6 router-id"
        vtysh -c "configure terminal" -c "no router ospf6"
      fi


### PR DESCRIPTION
Fix for deleting correct ospfv3 router-id
https://phabricator.vyos.net/T3858

```
set protocols ospfv3 area 0.0.0.0 interface eth0 
set protocols ospfv3 parameters router-id 192.168.122.15
```
vtysh
```
!
router ospf6
 ospf6 router-id 192.168.122.15
 interface eth0 area 0.0.0.0
!

```
Per deleting for some reason it trying to delete **router-id** instead of  **ospf6 router-id** 
After fix:
```
vyos@r5-1.3# delete protocols ospfv3 
[edit]
vyos@r5-1.3# commit
[edit]
vyos@r5-1.3# 

```