### PR TITLE
policy: T4293: backport ip-next-hop unchanged

### DIFF
--- a/templates/policy/route-map/node.tag/rule/node.tag/set/ip-next-hop/peer-address/node.def
+++ b/templates/policy/route-map/node.tag/rule/node.tag/set/ip-next-hop/peer-address/node.def
@@ -1,0 +1,12 @@
+help: Set the BGP nexthop address to the address of the peer
+
+commit:expression: $VAR(../../../action/) != ""; "you must specify an action"
+
+update: vtysh -c "configure terminal" \
+         -c "route-map $VAR(../../../../@) $VAR(../../../action/@) $VAR(../../../@)" \
+         -c "set ip next-hop peer-address"
+
+delete: vtysh -c "configure terminal" \
+         -c "route-map $VAR(../../../../@) $VAR(../../../action/@) $VAR(../../../@)" \
+         -c "no set ip next-hop peer-address"
+

--- a/templates/policy/route-map/node.tag/rule/node.tag/set/ip-next-hop/unchanged/node.def
+++ b/templates/policy/route-map/node.tag/rule/node.tag/set/ip-next-hop/unchanged/node.def
@@ -1,0 +1,12 @@
+help: Set the BGP nexthop address as unchanged
+
+commit:expression: $VAR(../../../action/) != ""; "you must specify an action"
+
+update: vtysh -c "configure terminal" \
+         -c "route-map $VAR(../../../../@) $VAR(../../../action/@) $VAR(../../../@)" \
+         -c "set ip next-hop unchanged"
+
+delete: vtysh -c "configure terminal" \
+         -c "route-map $VAR(../../../../@) $VAR(../../../action/@) $VAR(../../../@)" \
+         -c "no set ip next-hop unchanged"
+

--- a/templates/policy/route-map/node.tag/rule/node.tag/set/ipv6-next-hop/peer-address/node.def
+++ b/templates/policy/route-map/node.tag/rule/node.tag/set/ipv6-next-hop/peer-address/node.def
@@ -1,0 +1,12 @@
+help: Use peer address (for BGP only)
+
+commit:expression: $VAR(../../../action/) != ""; "you must specify an action"
+
+update: vtysh -c "configure terminal" \
+         -c "route-map $VAR(../../../../@) $VAR(../../../action/@) $VAR(../../../@)" \
+         -c "set ipv6 next-hop peer-address"
+
+delete: vtysh -c "configure terminal" \
+         -c "route-map $VAR(../../../../@) $VAR(../../../action/@) $VAR(../../../@)" \
+         -c "no set ipv6 next-hop peer-address"
+


### PR DESCRIPTION
This backports https://github.com/vyos/vyos-1x/pull/1243 to equuleus

This is a work in progress and doesn't currently work - this is my first time touching the pre-templates config system I'd like help figuring out why this doesn't work, if anyone has the time.

The `ipv6-next-hop peer-address` works perfectly, but the two IPv4 commands aren't passing validation:

```
[edit]
vyos@vyos# set policy route-map testing rule 1 set ip-next-hop
Possible completions:
   <x.x.x.x>    IP address



[edit]
vyos@vyos# set policy route-map testing rule 1 set ip-next-hop unchanged

  "unchanged" is not a valid value of type "ipv4"
  Value validation failed
  Set failed
```

I assume I need to change `ip-next-hop/node.def` in some way to let it allow entries to exist underneath itself. I've tried adding `tag:` to it as I've seen that used elsewhere, but that didn't seem to help. Is there any documentation or examples where this is done for other commands?