### PR TITLE
bgp listen: T1875: added BGP listen range feature

### DIFF
--- a/templates/protocols/bgp/node.tag/listen/limit/node.def
+++ b/templates/protocols/bgp/node.tag/listen/limit/node.def
@@ -1,0 +1,4 @@
+type: txt
+help: Maximum number of dynamic neighbors that can be created
+val_help: u32:1-5000; BGP neighbor limit
+syntax:expression: exec "${vyos_libexec_dir}/validate-value  --exec \"${vyos_validators_dir}/numeric --range 1-5000\"  --value \'$VAR(@)\'"; "Invalid value"

--- a/templates/protocols/bgp/node.tag/listen/node.def
+++ b/templates/protocols/bgp/node.tag/listen/node.def
@@ -1,0 +1,1 @@
+help: Listen for and accept BGP dynamic neighbors from range

--- a/templates/protocols/bgp/node.tag/listen/range/node.def
+++ b/templates/protocols/bgp/node.tag/listen/range/node.def
@@ -1,0 +1,7 @@
+tag:
+type: txt
+help: BGP dynamic neighbors listen range
+val_help: ipv4net; IPv4 dynamic neighbors listen range
+val_help: ipv6net; IPv6 dynamic neighbors listen range
+syntax:expression: exec "${vyos_libexec_dir}/validate-value  --exec \"${vyos_validators_dir}/ipv4-prefix \" --exec \"${vyos_validators_dir}/ipv6-prefix \"  --value \'$VAR(@)\'"; "Invalid value"
+commit:expression: exec "/opt/vyatta/sbin/vyatta-bgp.pl --check-bgp-listen --as $VAR(../../@)"

--- a/templates/protocols/bgp/node.tag/listen/range/node.tag/peer-group/node.def
+++ b/templates/protocols/bgp/node.tag/listen/range/node.tag/peer-group/node.def
@@ -1,0 +1,5 @@
+type: txt
+help: Peer group for this peer
+val_help: txt; Peer-group name
+allowed: /bin/cli-shell-api listNodes protocols bgp $VAR(../../../@) peer-group
+commit:expression: exec "/opt/vyatta/sbin/vyatta_quagga_utils.pl --exists \"protocols bgp $VAR(../../../@) peer-group $VAR(@)\" "; "protocols bgp $VAR(../../../@) peer-group $VAR(@) doesn't exist"


### PR DESCRIPTION
This change provides the same CLI structure as in 1.4 for the `protocols bgp listen` and must be fully compatible with future releases (no additional migration is required).