### PR TITLE
T4896: ospfv3: Fix broken not-advertise option

### DIFF
--- a/templates/protocols/ospfv3/area/node.tag/range/node.def
+++ b/templates/protocols/ospfv3/area/node.tag/range/node.def
@@ -3,18 +3,13 @@ type: ipv6net
 help: Specify IPv6 prefix (border routers only)
 syntax:expression: exec "ipaddrcheck --verbose --is-ipv6-net $VAR(@)"
 
-delete: touch /tmp/ospf6-range.$PPID
-
-end: if [ -f /tmp/ospf6-range.$PPID ]; then
-        vtysh -c "configure terminal" \
-          -c "router ospf6"                                        \
-          -c "no area $VAR(../@) range $VAR(@)";
-        rm /tmp/ospf6-range.$PPID;
-     else
-        vtysh --noerror -c "configure terminal" \
-          -c "router ospf6"                                               \
-          -c "no area $VAR(../@) range $VAR(@)";
-        vtysh -c "configure terminal" \
-          -c "router ospf6"                                        \
-          -c "area $VAR(../@) range $VAR(@)";
-     fi;
+create: if [ -z $VAR(./not-advertise/@) ] && [ -z $VAR(./advertise/@) ]; then
+          vtysh -c "configure terminal"                                       \
+            -c "router ospf6"                                                 \
+            -c "area $VAR(../@) range $VAR(@)";                               \
+        fi;
+delete: if [ -z $VAR(./not-advertise/@) ] && [ -z $VAR(./advertise/@) ]; then
+          vtysh -c "configure terminal"                                       \
+            -c "router ospf6"                                                 \
+            -c "no area $VAR(../@) range $VAR(@)";                            \
+        fi;


### PR DESCRIPTION
Config option `protocols ospfv3 area <number> range <prefix> not-advertise` is broken and behaves exactly same as `advertise`.

Steps to reproduce:

```
set protocols ospfv3 area 16 range 2000::/4 not-advertise
```

Actual result:

```
$ vtysh -c 'show run'
!
router ospf6
 area 16 range 2000::/4
```

Expected result:

```
$ vtysh -c 'show run'
!
router ospf6
 area 16 range 2000::/4 not-advertise
```

It seems to me that `templates/protocols/ospfv3/area/node.tag/range/node.def` overwrites `area $AREA range $RANGE` even if child node `no-advertise` is set. It seems to me the scripts in that file is used to make child option `advertise` optional. This PR changes it to only run when children options (advertise, not-advertise) are not set.