### PR TITLE
T5017: fix reference to no longer existing validator

### DIFF
--- a/templates/protocols/static/route/node.tag/dhcp-interface/node.def
+++ b/templates/protocols/static/route/node.tag/dhcp-interface/node.def
@@ -2,7 +2,7 @@ type: txt
 help: DHCP interface supplying next-hop IP address
 val_help: txt; DHCP interface name
 allowed: sh -c "${vyos_completion_dir}/list_interfaces.py"
-syntax:expression: exec "${vyos_libexec_dir}/validate-value  --exec \"${vyos_validators_dir}/interface-name \" --value \'$VAR(@)\'"; "Invalid value"
+syntax:expression: exec "${vyos_libexec_dir}/validate-value --regex \'(bond|br|dum|en|ersp|eth|gnv|lan|l2tp|l2tpeth|macsec|peth|ppp|pppoe|pptp|sstp|tun|veth|vti|vtun|vxlan|wg|wlan|wwan)[0-9]+(.\\d+)?|lo\' --exec \"${vyos_validators_dir}/file-path --lookup-path /sys/class/net --directory \"  --value \'$VAR(@)\'"; "Invalid value"
 create:
         sudo /opt/vyatta/sbin/vyatta-update-static-route.pl --interface=$VAR(@) --route=$VAR(../@) --table=main --option=create
         RIP=$(/opt/vyatta/sbin/vyatta-dhcp-helper.pl --interface=$VAR(@) --want=router)


### PR DESCRIPTION
The "interface-name" Python validator was removed for performance reasons. Reference new implemented validators