### PR TITLE
T4475: route-map allow IPv6 address for match peer option

### DIFF
--- a/scripts/policy/vyatta-policy.pl
+++ b/scripts/policy/vyatta-policy.pl
@@ -45,6 +45,7 @@ sub check_peer_syntax {
     $_ = $peer;
     if (/^local$/) { exit 0; }
     if ( isIpAddress("$peer") ) { exit 0; }
+    if ( $peer =~ /^[0-9a-fA-F:]+$/) { exit 0; }
     exit 1;
 }
 

--- a/templates/policy/route-map/node.tag/rule/node.tag/match/peer/node.def
+++ b/templates/policy/route-map/node.tag/rule/node.tag/match/peer/node.def
@@ -1,6 +1,7 @@
 type: txt
 help: Peer address to match
 val_help: ipv4; Peer IP address
+val_help: ipv6; Peer IPv6 address
 val_help: local: Static or redistributed routes
 
 syntax:expression: exec "/opt/vyatta/sbin/vyatta-policy.pl --check-peer-syntax $VAR(@)"; "peer must be either an IP or local"


### PR DESCRIPTION

https://vyos.dev/T4475

Add ability to set match IPv6 peer address for route-map
Before the fix:
```
vyos@r1# set policy route-map foo rule 100 match peer fe80::2

  peer must be either an IP or local
  Value validation failed
  Set failed

[edit]
vyos@r1# 

```
After the fix:
```
set policy route-map foo rule 100 action 'permit'
set policy route-map foo rule 100 match peer 'fe80::2'
```
Vtysh:
```
!
route-map foo permit 100
 match peer fe80::2
!

```