### PR TITLE
T5576: Add BGP remove-private-as all option

### DIFF
--- a/scripts/bgp/vyatta-bgp.pl
+++ b/scripts/bgp/vyatta-bgp.pl
@@ -370,6 +370,10 @@ my %qcom = (
       set => 'router bgp #3 ; address-family ipv6 ; neighbor #5 remove-private-AS',
       del => 'router bgp #3 ; address-family ipv6 ; no neighbor #5 remove-private-AS',
   },
+  'protocols bgp var neighbor var address-family ipv6-unicast remove-private-as all' => {
+      set => 'router bgp #3 ; address-family ipv6 ; neighbor #5 remove-private-AS all',
+      del => 'router bgp #3 ; address-family ipv6 ; no neighbor #5 remove-private-AS all',
+  },
   'protocols bgp var neighbor var address-family ipv6-unicast route-map' => {
       set => undef,
       del => undef,
@@ -513,6 +517,10 @@ my %qcom = (
   'protocols bgp var neighbor var address-family ipv4-unicast remove-private-as' => {
       set => 'router bgp #3 ; address-family ipv4 unicast ; neighbor #5 remove-private-AS',
       del => 'router bgp #3 ; address-family ipv4 unicast ; no neighbor #5 remove-private-AS',
+  },
+  'protocols bgp var neighbor var address-family ipv4-unicast remove-private-as all' => {
+      set => 'router bgp #3 ; address-family ipv4 unicast ; neighbor #5 remove-private-AS all',
+      del => 'router bgp #3 ; address-family ipv4 unicast ; no neighbor #5 remove-private-AS all',
   },
   'protocols bgp var neighbor var address-family ipv4-unicast route-map' => {
       set => undef,
@@ -964,6 +972,10 @@ my %qcom = (
       set => 'router bgp #3 ; address-family ipv6 ; neighbor #5 remove-private-AS',
       del => 'router bgp #3 ; address-family ipv6 ; no neighbor #5 remove-private-AS',
   },
+  'protocols bgp var peer-group var address-family ipv6-unicast remove-private-as all' => {
+      set => 'router bgp #3 ; address-family ipv6 ; neighbor #5 remove-private-AS all',
+      del => 'router bgp #3 ; address-family ipv6 ; no neighbor #5 remove-private-AS all',
+  },
   'protocols bgp var peer-group var address-family ipv6-unicast route-map' => {
       set => undef,
       del => undef,
@@ -1105,6 +1117,10 @@ my %qcom = (
   'protocols bgp var peer-group var address-family ipv4-unicast remove-private-as' => {
       set => 'router bgp #3 ; address-family ipv4 unicast ; neighbor #5 remove-private-AS',
       del => 'router bgp #3 ; address-family ipv4 unicast ; no neighbor #5 remove-private-AS',
+  },
+  'protocols bgp var peer-group var address-family ipv4-unicast remove-private-as all' => {
+      set => 'router bgp #3 ; address-family ipv4 unicast ; neighbor #5 remove-private-AS all',
+      del => 'router bgp #3 ; address-family ipv4 unicast ; no neighbor #5 remove-private-AS all',
   },
   'protocols bgp var peer-group var address-family ipv4-unicast route-map' => {
       set => undef,

--- a/templates/protocols/bgp/node.tag/neighbor/node.tag/address-family/ipv4-unicast/remove-private-as/all/node.def
+++ b/templates/protocols/bgp/node.tag/neighbor/node.tag/address-family/ipv4-unicast/remove-private-as/all/node.def
@@ -1,0 +1,1 @@
+help: Remove private AS numbers to all AS numbers in outbound route updates

--- a/templates/protocols/bgp/node.tag/neighbor/node.tag/address-family/ipv6-unicast/remove-private-as/all/node.def
+++ b/templates/protocols/bgp/node.tag/neighbor/node.tag/address-family/ipv6-unicast/remove-private-as/all/node.def
@@ -1,0 +1,1 @@
+help: Remove private AS numbers to all AS numbers in outbound route updates

--- a/templates/protocols/bgp/node.tag/peer-group/node.tag/address-family/ipv4-unicast/remove-private-as/all/node.def
+++ b/templates/protocols/bgp/node.tag/peer-group/node.tag/address-family/ipv4-unicast/remove-private-as/all/node.def
@@ -1,0 +1,1 @@
+help: Remove private AS numbers to all AS numbers in outbound route updates

--- a/templates/protocols/bgp/node.tag/peer-group/node.tag/address-family/ipv6-unicast/remove-private-as/all/node.def
+++ b/templates/protocols/bgp/node.tag/peer-group/node.tag/address-family/ipv6-unicast/remove-private-as/all/node.def
@@ -1,0 +1,1 @@
+help: Remove private AS numbers to all AS numbers in outbound route updates


### PR DESCRIPTION
Add the ability to use the option `all` for `remove-private-as`. Remove private ASNs in outbound updates.
`al`l - Apply to all AS numbers

## Task
  https://vyos.dev/T5576

## Check
VyOS configuration
```
set protocols bgp 65001 neighbor 10.0.0.2 address-family ipv4-unicast remove-private-as all
set protocols bgp 65001 neighbor 10.0.0.2 remote-as '65002'
set protocols bgp 65001 neighbor aa::1 address-family ipv6-unicast remove-private-as all
set protocols bgp 65001 neighbor aa::1 remote-as '65003'
set protocols bgp 65001 parameters default no-ipv4-unicast
set protocols bgp 65001 peer-group PGRP address-family ipv4-unicast remove-private-as all
```
FRR configuration:
```
!
router bgp 65001
 no bgp ebgp-requires-policy
 no bgp default ipv4-unicast
 no bgp network import-check
 neighbor PGRP peer-group
 neighbor 10.0.0.2 remote-as 65002
 neighbor aa::1 remote-as 65003
 !
 address-family ipv4 unicast
  neighbor PGRP activate
  neighbor PGRP remove-private-AS all
  neighbor 10.0.0.2 activate
  neighbor 10.0.0.2 remove-private-AS all
 exit-address-family
 !
 address-family ipv6 unicast
  neighbor aa::1 activate
  neighbor aa::1 remove-private-AS all
 exit-address-family
!

```