### PR TITLE
T6196: Fixed applying parameters for aggregation in BGP

### DIFF
--- a/scripts/bgp/vyatta-bgp.pl
+++ b/scripts/bgp/vyatta-bgp.pl
@@ -64,12 +64,8 @@ my %qcom = (
       del => undef,
   },
   'protocols bgp var address-family ipv6-unicast aggregate-address var' => {
-      set => 'router bgp #3 ; address-family ipv6 ; aggregate-address #7 ?summary-only',
-      del => 'router bgp #3 ; address-family ipv6 ; no aggregate-address #7',
-  },
-  'protocols bgp var address-family ipv6-unicast aggregate-address var route-map' => {
-      set => 'router bgp #3 ; address-family ipv6 unicast ; no aggregate-address #7 ; aggregate-address #7 route-map #9',
-      del => 'router bgp #3 ; address-family ipv6 unicast ; no aggregate-address #7 route-map #9 ; aggregate-address #7',
+      set => 'router bgp #3 ; address-family ipv6 ; aggregate-address #7 ?summary-only ?route-map',
+      del => 'router bgp #3 ; address-family ipv6 ; no aggregate-address #7 ?summary-only ?route-map',
   },
   'protocols bgp var address-family ipv6-unicast network' => {
       set => undef,
@@ -147,12 +143,8 @@ my %qcom = (
       del => undef,
   },
   'protocols bgp var address-family ipv4-unicast aggregate-address var' => {
-      set => 'router bgp #3 ; address-family ipv4 unicast ; aggregate-address #7 ?as-set ?summary-only',
-      del => 'router bgp #3 ; address-family ipv4 unicast ; no aggregate-address #7 ?as-set ?summary-only',
-  },
-  'protocols bgp var address-family ipv4-unicast aggregate-address var route-map' => {
-      set => 'router bgp #3 ; address-family ipv4 unicast ; no aggregate-address #7 ; aggregate-address #7 route-map #9',
-      del => 'router bgp #3 ; address-family ipv4 unicast ; no aggregate-address #7 route-map #9 ; aggregate-address #7',
+      set => 'router bgp #3 ; address-family ipv4 unicast ; aggregate-address #7 ?as-set ?summary-only ?route-map',
+      del => 'router bgp #3 ; address-family ipv4 unicast ; no aggregate-address #7 ?as-set ?summary-only ?route-map',
   },
   'protocols bgp var address-family ipv4-unicast network' => {
       set => undef,


### PR DESCRIPTION
Fixed using 'route-map', 'as-set' and 'summary-only' together in aggregation in BGP.
Backported from circinus [https://github.com/vyos/vyos-1x/pull/3232](https://github.com/vyos/vyos-1x/pull/3232)
Task
https://vyos.dev/T6196
Smoketests:
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_bgp.py
test_bgp_01_simple (__main__.TestProtocolsBGP) ... ok
test_bgp_02_neighbors (__main__.TestProtocolsBGP) ... ok
test_bgp_03_peer_groups (__main__.TestProtocolsBGP) ... ok
test_bgp_04_afi_ipv4 (__main__.TestProtocolsBGP) ... ok
test_bgp_05_afi_ipv6 (__main__.TestProtocolsBGP) ... ok

----------------------------------------------------------------------
Ran 5 tests in 30.338s

OK
```
