### PR TITLE
T3437: Removed warning Perl messages after adding peer to confederation

### DIFF
--- a/scripts/bgp/vyatta-bgp.pl
+++ b/scripts/bgp/vyatta-bgp.pl
@@ -1706,16 +1706,22 @@ sub confed_iBGP_ASN {
     my @neighbors = $config->listOrigNodes('neighbor');
     foreach my $neighbor (@neighbors) {
       my $remoteas = $config->returnValue("neighbor $neighbor remote-as");
-      if (("$testas" eq "$remoteas") || ("$testas" eq "internal")) {
-        exit 1;
+      if (defined $remoteas) {
+        if (("$testas" eq "$remoteas") || ("$testas" eq "internal")) {
+          exit 1;
+        }
       }
       $remoteas = $config->returnValue("neighbor $neighbor interface remote-as");
-      if (("$testas" eq "$remoteas") || ("$testas" eq "internal")) {
-        exit 1;
+      if (defined $remoteas) {
+        if (("$testas" eq "$remoteas") || ("$testas" eq "internal")) {
+          exit 1;
+        }
       }
       $remoteas = $config->returnValue("neighbor $neighbor interface v6only remote-as");
-      if (("$testas" eq "$remoteas") || ("$testas" eq "internal")) {
-        exit 1;
+      if (defined $remoteas) {
+        if (("$testas" eq "$remoteas") || ("$testas" eq "internal")) {
+            exit 1;
+        }
       }
     }
 


### PR DESCRIPTION
Removed warning Perl messages after adding peer to BGP confederation.
Fixed using uninitialized variables.
According to https://vyos.dev/T3437
Before:
```
vyos@vyos# commit
[ protocols bgp 4242420666 parameters confederation peers 4242420665 ]
Use of uninitialized value $remoteas in string at /opt/vyatta/sbin/vyatta-bgp.pl line 1709.
Use of uninitialized value $remoteas in string at /opt/vyatta/sbin/vyatta-bgp.pl line 1713.
Use of uninitialized value $remoteas in string at /opt/vyatta/sbin/vyatta-bgp.pl line 1717.
```
After:
```
vyos@vyos# set protocols bgp 4242420666 parameters confederation peers '4242420665'
[edit]
vyos@vyos# commit
[edit]
vyos@vyos#
```
Smoketests
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_bgp.py
test_bgp_01_simple (__main__.TestProtocolsBGP) ... ok
test_bgp_02_neighbors (__main__.TestProtocolsBGP) ... ok
test_bgp_03_peer_groups (__main__.TestProtocolsBGP) ... ok
test_bgp_04_afi_ipv4 (__main__.TestProtocolsBGP) ... ok
test_bgp_05_afi_ipv6 (__main__.TestProtocolsBGP) ... ok

----------------------------------------------------------------------
Ran 5 tests in 30.845s

OK

```